### PR TITLE
Updates to "p_" characters

### DIFF
--- a/edition.xml
+++ b/edition.xml
@@ -1187,6 +1187,481 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="70" />
         ex matre uirgine. sed eius incarnatio erat predestinata
 
+<!--Inserting lines 71-109-->
+
+    <lb n="71" />
+        <choice>
+          <abbr>&amp;erno</abbr>
+          <expan>eterno</expan>
+        </choice>
+        consilio patris; Ipse enim est 
+        <choice>
+          <orig>p&#x0331;fectus</orig>
+          <reg>perfectus</reg>
+        </choice>
+        <choice>
+          <abbr>d<g ref="#s_macron"/></abbr>
+          <expan>deus</expan>
+        </choice>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>p&#x0331;fec<g ref="#t_macron"/></abbr>
+          <expan>perfectus</expan>
+        </choice>
+
+        <lb n="72" />
+        homo. in duabus naturis
+        <choice>
+          <abbr>d<g ref="#i_macron"/></abbr>
+          <expan>dei</expan>
+        </choice>
+        <choice>
+          <abbr>&amp;hominis</abbr>
+          <expan>et hominis</expan>
+        </choice>
+        existens una
+        <choice>
+          <abbr>p&#x0331;sona</abbr>
+          <expan>persona</expan>
+        </choice>
+        <lb n="73" />
+        <choice>
+          <abbr>intant<g ref="#u_macron"/></abbr>
+          <expan>in tantum</expan>
+        </choice>
+        ut idem sit filius 
+        <choice>
+          <abbr>d<g ref="#i_macron"/></abbr>
+          <expan>dei</expan>
+        </choice> 
+        qui filius hominis.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        filius
+
+        <lb n="74" />
+        hominis qui filius
+        <choice>
+          <abbr>d<g ref="#i_macron"/></abbr>
+          <expan>dei</expan>
+        </choice>
+        unus
+        <choice>
+          <orig lang="GK">xps</orig>
+          <reg>christus</reg>
+        </choice>
+        ; Creaturae uero quas unus
+
+        <lb n="75" />
+        creator creauit multiplices sunt.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        uariae figurae.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+
+        <lb n="76" />
+        non uno modo uiuunt; ex quibus
+        <choice>
+          <orig>quaed<g ref="#a_macron"/></orig>
+          <reg>quaedam</reg>
+        </choice>
+        sunt incorpora
+
+        <lb n="77" />
+        lia
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        inuisibilia; ut angeli in caelo nullo terreno cibo
+
+        <lb n="78" />
+        utentes; Alia
+        <choice>
+          <orig>namq:</orig>
+          <reg>namque</reg>
+        </choice>
+        corporalia sunt ratione carentia
+
+        <lb n="79" />
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        toto corpore in terra reptantia sicut uermes; Quae
+
+        <lb n="80" />
+        dam uero ambulant
+        <choice>
+          <orig>duob:</orig>
+          <reg>duobus</reg>
+        </choice>
+        pedibus
+        <choice>
+          <orig>qued<g ref="#a_macron"/></orig>
+          <reg>quedam</reg>
+        </choice>
+        quattuor;
+
+        <lb n="81" />
+        <choice>
+          <orig>Quaed<g ref="#a_macron"/></orig>
+          <reg>Quaedam</reg>
+        </choice>
+        pennis uolant in aere.
+        <choice>
+          <orig>quaed<g ref="#a_macron"/></orig>
+          <reg>quaedam</reg>
+        </choice>
+        etiam natatilia sunt
+
+        <lb n="82" />
+        ut pissces in mari.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        in amne uagantia: quae sine aquis
+
+        <lb n="83" />
+        uiuere nequeunt
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        nos in aquis suffocamur; Omnia
+
+        <lb n="84" />
+        tamen ad
+        <choice>
+          <orig>terr<g ref="#a_macron"/></orig>
+          <reg>terram</reg>
+        </choice>
+        <choice>
+          <orig>inclinan<g ref="#t_macron"/></orig>
+          <reg>inclinantur</reg>
+        </choice>
+        de qua alimenta sumunt:
+
+        <lb n="85" />
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        quicquid desiderant uel indigent; Sed homo solus recta
+
+        <lb n="86" />
+        statura ambulat. qui ad
+        <choice>
+          <abbr>imagin<g ref="#e_macron"/></abbr>
+          <expan>imageinem</expan>
+        </choice>
+        dei creatus est
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>p&#x0331;prio</abbr>
+          <expan>proprio</expan>
+        </choice>
+
+        <lb n="87" />
+        incessu significat quod 
+        <choice>
+          <abbr>deb&amp;</abbr>
+          <expan>debet</expan>
+        </choice>
+        plus de
+        <choice>
+          <abbr>celestib:</abbr>
+          <expan>celestibus</expan>
+        </choice>
+        meditari
+
+        <lb n="88" />
+        <choice>
+          <abbr>qu<g ref="#a_macron"/></abbr>
+          <expan>quam</expan>
+        </choice>
+        de terrenis, plus de eternis
+        <choice>
+          <abbr>qu<g ref="#a_macron"/></abbr>
+          <expan>quam</expan>
+        </choice>
+        de infimis. ne forte
+
+        <lb n="89" />
+        mens
+        <choice>
+          <abbr>e<g ref="#i_macron"/></abbr>
+          <expan>eius</expan>
+        </choice>
+        fiat inferior corpore; Ergo ille homo qui
+        <choice>
+          <abbr>semp&#x0331;<macron/></abbr>
+          <expan>semper</expan>
+        </choice>
+
+        <lb n="90" />
+        <choice>
+          <abbr>inher&amp;</abbr>
+          <expan>inheret</expan>
+        </choice>
+        infimis de caducis cogitans nonne est quasi uermis
+
+        <lb n="91" />
+        qui toto corpore serpit? nolite
+        <choice>
+          <abbr>f<g ref="#r_macron"/>s</abbr>
+          <expan>fratres</expan>
+        </choice>
+        esse serpentes uenenati.
+
+        <lb n="92" />
+        nocentes inuicem;
+        <choice>
+          <abbr>Iter<g ref="#u_macron"/></abbr>
+          <expan>Iterum</expan>
+        </choice>
+        nolite incurui incedere ut
+        <choice>
+          <abbr>iu<g ref="#m_macron"/>ta</abbr>
+          <expan>iumenta</expan>
+        </choice>;
+
+        <lb n="93" />
+        solam
+        <choice>
+          <abbr>terr<g ref="#a_macron"/></abbr>
+          <expan>terram</expan>
+        </choice>
+        aspicientes. ne forte dicat
+        <choice>
+          <abbr>uo<g ref="#b_macron"/></abbr>
+          <expan>uobis</expan>
+        </choice>
+        psalmista;
+
+        <lb n="94" />
+        <choice>
+          <abbr>Obscuren<g ref="#t_macron"/></abbr>
+          <expan>Obscurentur</expan>
+        </choice>
+        oculi
+        <choice>
+          <abbr>eo</abbr>
+          <expan>eorum</expan>
+        <!--PSI LOOKING SYMBOL? -->
+        </choice>
+        ne uideant: 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        dorsa
+        <choice>
+          <abbr>eo</abbr>
+          <expan>eorum</expan>
+        <!--PSI LOOKING SYMBOL? -->
+        </choice>
+        semper
+
+        <lb n="95" />
+        incurua; Erigite capita
+        <choice>
+          <abbr>u<g ref="#r_macron"/>a</abbr>
+          <expan>uestra</expan>
+        </choice>: 
+        ambulate ut homines
+
+        <pb n="15r" facs="data/images/fol_5v.png" />
+
+        <lb n="96" />
+        rationabiles; State in fide uiriliter agite
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        confortamini
+
+        <lb n="97" />
+        omnia
+        <choice>
+          <abbr>u<g ref="#r_macron"/>a</abbr>
+          <expan>uestra</expan>
+        </choice>
+        <choice>
+          <abbr>c<g ref="#u_macron"/></abbr>
+          <expan>cum</expan>
+        </choice>
+        caritate fiant; Nolite esse bruta anima
+
+        <lb n="98" />
+        lia. intelligite quia serpens
+        <choice>
+          <abbr>terr<g ref="#a_macron"/></abbr>
+          <expan>terram</expan>
+        </choice>
+        comedit cunctis
+        <choice>
+          <abbr>dieb:</abbr>
+          <expan>diebus</expan>
+        </choice>
+
+        <lb n="99" />
+        uitae suae:
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        bos herbis pascitur. uobis
+        <choice>
+          <abbr>aut<g ref="#e_macron"/></abbr>
+          <expan>autem</expan>
+        </choice>
+        dedit
+        <choice>
+          <abbr>d<g ref="#s_macron"/></abbr>
+          <expan>deus</expan>
+        </choice>
+
+        <lb n="100" />
+        panem ad
+        <choice>
+          <abbr>uescend<g ref="#u_macron"/></abbr>
+          <expan>uescendum</expan>
+        </choice>;
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>Et</expan>
+        </choice>
+        non
+        <choice>
+          <abbr>sol<g ref="#u_macron"/></abbr>
+          <expan>solum</expan>
+        </choice>
+        <choice>
+          <abbr>pan<g ref="#e_macron"/></abbr>
+          <expan>panem</expan>
+        </choice>
+        terrenis
+        <choice>
+          <abbr>dapibu:</abbr>
+          <expan>dapibus</expan>
+        </choice>
+        <choice>
+          <abbr><g ref="#p_macron"/>para</abbr>
+          <expan>praepara</expan>
+        </choice>
+
+        <lb n="101" />
+        tum sed etiam
+        <choice>
+          <abbr>pan<g ref="#e_macron"/></abbr>
+          <expan>panem</expan>
+        </choice>
+        <choice>
+          <abbr>angelo</abbr>
+<!--Come back and add in rum character-->
+          <expan>angelorum</expan>
+        </choice>
+        qui de celo descendit. qui hodie
+
+        <lb n="102" />
+        natus est nobis ex inmaculata uirgine maria. qui dixit;
+
+        <lb n="103" />
+        Ego
+        <choice>
+          <abbr>s<g ref="#u_macron"/></abbr>
+          <expan>sum</expan>
+        </choice>
+        panis uiuus qui de celo descendi: si quis manducaue
+
+        <lb n="104" />
+        rit ex hoc pane 
+        <choice>
+          <abbr>uiu&amp;</abbr>
+          <expan>uiuet</expan>
+        </choice>
+        in aeternum; Et panis
+        <choice>
+          <abbr>qu<g ref="#e_macron"/></abbr>
+          <expan>quem</expan>
+        </choice>
+        ego dabo
+
+        <lb n="105" />
+        caro mea est
+        <choice>
+          <abbr>p&#x0331;</abbr>
+          <expan>pro</expan>
+        </choice>
+        mundi uita: Istum panem
+        <choice>
+          <abbr>deniq:</abbr>
+          <expan>denique</expan>
+        </choice>
+        manduca
+
+        <lb n="106" />
+        mus cum ad sacrificium
+        <choice>
+          <orig lang="GK">xpi</orig>
+          <reg>christi</reg>
+        </choice>
+        <choice>
+          <abbr>c<g ref="#u_macron"/></abbr>
+          <expan>cum</expan>
+        </choice>
+        fide accedimus; Nam
+
+        <lb n="107" />
+        hodie debent
+        <choice>
+          <orig lang="GK">xpiani</orig>
+          <reg>christiani</reg>
+        </choice>
+        accedere ad
+        <choice>
+          <orig>sacrifici<g ref="#u_macron"/></orig>
+          <reg>sacrificium</reg>
+        </choice>
+        <choice>
+          <orig lang="GK">xpi</orig>
+          <reg>christi</reg>
+        </choice>
+        . quia ual
+
+        <lb n="108" />
+        de raro
+        <choice>
+          <orig>c<g ref="#u_macron"/>municat</orig>
+          <reg>cummunicat</reg>
+        </choice>
+        qui semel in anno communicat. Cum
+
+        <lb n="109" />
+        canones
+        <choice>
+          <orig>dign<g ref="#u_macron"/></orig>
+          <reg>dignum</reg>
+        </choice>
+        doce<add place="above">a</add>nt excommunicatione qui tres domini
+
+<!--End insertion of lines 71-109-->
+
     <pb n="15r" facs="015r.jpg"/>
         <lb n="110" />
         cas dies 
@@ -1339,14 +1814,19 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="121" />
         carentes substantiis; Nonne
         <choice>
-          <orig>ess<g ref="amp"/></orig>
+          <orig>ess&amp;</orig>
           <reg>esset</reg>
         </choice>
-         melius <g ref="amp"/> sapientius
+        melius 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        sapientius
         <lb n="122" />
         ut tu diligeres
         <choice>
-          <orig><g ref="#p_macron"/>ximum</orig>
+          <orig>p&#x0331;ximum</orig>
           <reg>proximum</reg>
         </choice>
         <choice>
@@ -1358,7 +1838,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>d<g ref="#s_macron"/></orig>
           <reg>deus</reg>
         </choice>
-        precepit <g ref="amp"/> ipse
+        precepit 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        ipse
         <lb n="123" />
         <choice>
           <orig>diliger<g ref="amp"/></orig>
@@ -1371,17 +1856,21 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         tu
         <choice>
-          <orig><g ref="#p_macron"/>deres</orig>
+          <orig>p&#x0331;deres</orig>
           <reg>perderes</reg>
         </choice>
         <choice>
           <orig>eū</orig>
           <reg>eum</reg>
         </choice>
-        et ipse te decipiendo; Duo
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        ipse te decipiendo; Duo
         <lb n="124" />
         <choice>
-          <orig>namq</orig>
+          <orig>namq:</orig>
           <reg>namque</reg>
         </choice>
         uerba precepit
@@ -1389,7 +1878,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>d<g ref="#s_macron"/></orig>
           <reg>deus</reg>
         </choice>
-        omnibus
+        <choice>
+          <orig>omnib:</orig>
+          <reg>omnibus</reg>
+        </choice>
         <choice>
           <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>anis</orig>
           <reg>christianis</reg>

--- a/edition.xml
+++ b/edition.xml
@@ -1627,7 +1627,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="106" />
         mus cum ad sacrificium
         <choice>
-          <orig><foreign xml:lang="grc">xpi</foreign></orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/>i</foreign></orig>
           <reg>christi</reg>
         </choice>
         <choice>
@@ -1639,7 +1639,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="107" />
         hodie debent
         <choice>
-          <orig><foreign xml:lang="grc">xpiani</foreign></orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/>iani</foreign></orig>
           <reg>christiani</reg>
         </choice>
         accedere ad
@@ -1648,7 +1648,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>sacrificium</reg>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc">xpi</foreign></orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/>i</foreign></orig>
           <reg>christi</reg>
         </choice>
         . quia ual
@@ -3217,10 +3217,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>maleque</expan>
         </choice>
         uoluntatis capax. sed
+        <add place="above">
         <choice>
           <abbr>d<g ref="#m_macron"/></abbr>
           <expan>domini</expan>
         </choice>
+        </add>
         benignitate creatoris
 
         <lb n="237" />
@@ -3529,7 +3531,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>cuiq:</orig>
           <reg>cuique</reg>
         </choice>
-        consentiat in desiderio suae naturae. ne quid in
+        consentiat in desiderio suae naturae. ne quid i<hi rend="smallcaps">n</hi>
         <lb n="262" />
         <choice>
           <orig>do<add place="above">e</add>cens</orig>
@@ -3706,7 +3708,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>d<g ref="#n_macron"/>o</orig>
           <reg>domino</reg>
         </choice>
-        deo est; Pro inde omnis qui
+        deo est; Pro i<hi rend="smallcaps">n</hi>de omnis qui
         <choice>
           <orig>sc<g ref="#d_macron"/>m</orig>
           <reg>secundum</reg>

--- a/edition.xml
+++ b/edition.xml
@@ -252,6 +252,12 @@
         <mapping type="normalized">ꝵ</mapping>
         <mapping type="diplomatic">ꝵ</mapping>
     </char>
+    <char xml:id=“p_with_flourish>
+        <localProp name="name"
+            value="Latin Small Letter P With Flourish"/>
+        <mapping type="normalized">ꝓ</mapping>
+        <mapping type="diplomatic">ꝓ</mapping>
+    </char>
         </charDecl>
     </encodingDesc>
 		<revisionDesc>
@@ -308,7 +314,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
           maria uirgine
           <choice>
-            <orig>p&#x0331;</orig>
+            <orig><g ref="#p_with_flourish"/></orig>
             <reg>pro</reg>
           </choice>
           salute mundi. sed tamen
@@ -318,7 +324,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           </choice>
         <lb n="4" />
           <choice>
-            <orig>p&#x0331;</orig>
+            <orig><g ref="#p_with_flourish"/></orig>
             <reg>pro</reg>
           </choice>
         huius diei sollempnitate. uestras mentes aliqua spirita
@@ -564,7 +570,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="22" />
         mi, quia
         <choice>
-          <orig>ppheta</orig>
+          <orig><g ref="#p_with_flourish"/>pheta</orig>
           <reg>propheta</reg>
         </choice>
          dicit; Nisi credideritis non intellegitis;
@@ -1378,7 +1384,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>p&#x0331;prio</abbr>
+          <abbr><g ref="#p_with_flourish"/>prio</abbr>
           <expan>proprio</expan>
         </choice>
 
@@ -1608,7 +1614,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="105" />
         caro mea est
         <choice>
-          <abbr>p&#x0331;</abbr>
+          <abbr><g ref="#p_with_flourish"/></abbr>
           <expan>pro</expan>
         </choice>
         mundi uita: Istum panem
@@ -1829,7 +1835,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="122" />
         ut tu diligeres
         <choice>
-          <orig>p&#x0331;ximum</orig>
+          <orig><g ref="#p_with_flourish"/>ximum</orig>
           <reg>proximum</reg>
         </choice>
         <choice>
@@ -2308,7 +2314,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>per</expan>
         </choice>
         <choice>
-          <abbr>p&#x0331;phetam</abbr>
+          <abbr><g ref="#p_with_flourish"/>phetam</abbr>
           <expan>prophetam</expan>
         </choice>
         ; Omnem flatum
@@ -2428,7 +2434,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>salutem</expan>
         </choice>
         <choice>
-          <abbr>p&#x0331;ficiant</abbr>
+          <abbr><g ref="#p_with_flourish"/>ficiant</abbr>
           <expan>proficiant</expan>
         </choice>
         <choice>
@@ -2468,7 +2474,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         seruus est peccati; Ex qua corrupta
         <choice>
-          <abbr>p&#x0331;cedit</abbr>
+          <abbr><g ref="#p_with_flourish"/>cedit</abbr>
           <expan>procedit</expan>
         </choice>
 
@@ -2520,7 +2526,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>p&#x0331;ficiendo</abbr>
+          <abbr><g ref="#p_with_flourish"/>ficiendo</abbr>
           <expan>proficiendo</expan>
         </choice>
         ad uirtutem non maior fit. sed melior
@@ -3132,7 +3138,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="228" />
         Fortitudo, qua
         <choice>
-          <abbr>p&#x0331;</abbr>
+          <abbr><g ref="#p_with_flourish"/></abbr>
           <expan>pro</expan>
         </choice>
         dei amore fortiter omnia aduersa
@@ -3167,7 +3173,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         illis
         <choice>
-          <abbr>p&#x0331;desse</abbr>
+          <abbr><g ref="#p_with_flourish"/>desse</abbr>
           <expan>prodesse</expan>
         </choice>
 
@@ -3182,7 +3188,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="234" />
         iuxta suae
         <choice>
-          <abbr>p&#x0331;prietatem</abbr>
+          <abbr><g ref="#p_with_flourish"/>prietatem</abbr>
           <expan>proprietatem</expan>
         </choice>
         naturae; Anima est
@@ -3474,7 +3480,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="256" />
         nificationes non intellegens. ore
         <choice>
-          <orig>p&#x0331;fert.</orig>
+          <orig><g ref="#p_with_flourish"/>fert.</orig>
           <reg>profert.</reg>
         </choice>
         psallit mente

--- a/edition.xml
+++ b/edition.xml
@@ -452,21 +452,17 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         breuis responsio:
         <choice>
-          <abbr>&amp;</abbr>
-          <expan>et</expan>
-        </choice>
-        <choice>
-          <orig>quā</orig>
-          <reg>quam</reg>
+          <orig>&amp;quā</orig>
+          <reg>et quam</reg>
         </choice>
         profunda sit; Ergo
       <lb n="14" />
         pater est principium
         <choice>
-          <orig>&amp;</orig>
-          <reg>et</reg>
+          <orig>&amp;filius</orig>
+          <reg>et filius</reg>
         </choice>
-        filius qui ex patre natus est
+        qui ex patre natus est
         <choice>
           <orig>principiū</orig>
           <reg>principium</reg>
@@ -487,7 +483,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
          </choice>
         qui est caritas
         <choice>
-          <orig>ambō</orig>
+          <orig>ambo</orig>
           <reg>amborum</reg>
         </choice>
         <choice>
@@ -510,11 +506,11 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="17" />
         deitate
         <choice>
-          <orig>sem<g ref="#p_macron"/></orig>
+          <orig>semp&#x0331;</orig>
           <reg>semper</reg>
         </choice>
         <choice>
-          <orig><g ref="#p_macron"/>manens</orig>
+          <orig>p&#x0331;manens</orig>
           <reg>permanens</reg>
         </choice>
         : non inceptus. nec finitus; Sed ille
@@ -544,7 +540,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         non est creatura nec tempus
         <choice>
-          <orig><g ref="#p_macron"/>manens</orig>
+          <orig>p&#x0331;manens</orig>
           <reg>permanens</reg>
         </choice>
          quod
@@ -574,7 +570,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
          ualde altiora
         <lb n="24" />
-        se quaerit. qui uechors p[er]scrutando transscendere uult
+        se quaerit. qui uechors 
+        <choice>
+          <abbr>p&#x0331;scrutando</abbr>
+          <expan>perscrutando</expan>
+        </choice>
+        transscendere uult
         <choice>
           <orig><foreign xml:lang="grc">x<g ref="#r_macron"/></foreign>m,</orig>
             <reg>christum,</reg>

--- a/edition.xml
+++ b/edition.xml
@@ -296,7 +296,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>iesus</expan>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/>s</foreign></orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/>s</foreign></orig>
           <reg>christus</reg>
         </choice>
         hac ipsa die natus sit uera humanita
@@ -434,7 +434,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         interrogauerunt
         <choice>
-          <orig><foreign xml:lang="grc"/>x<g ref="#r_macron"/></foreign>m</orig>
+          <orig><foreign xml:lang="grc">x<g ref="#r_macron"/></foreign>m</orig>
           <reg>Christum</reg>
         </choice>
         dicen
@@ -583,7 +583,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         transscendere uult
         <choice>
-          <orig><foreign xml:lang="grc"/>x<g ref="#r_macron"/></foreign>m,</orig>
+          <orig><foreign xml:lang="grc">x<g ref="#r_macron"/></foreign>m,</orig>
             <reg>christum,</reg>
           </choice>
         <lb n="25" />
@@ -1258,7 +1258,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         unus
         <choice>
-          <orig><foreign xml:lang="grc"/>xps</orig>
+          <orig><foreign xml:lang="grc">xps</foreign></orig>
           <reg>christus</reg>
         </choice>
         ; Creaturae uero quas unus
@@ -1621,7 +1621,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="106" />
         mus cum ad sacrificium
         <choice>
-          <orig><foreign xml:lang="grc"/>xpi</orig>
+          <orig><foreign xml:lang="grc">xpi</foreign></orig>
           <reg>christi</reg>
         </choice>
         <choice>
@@ -1633,7 +1633,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="107" />
         hodie debent
         <choice>
-          <orig><foreign xml:lang="grc"/>xpiani</orig>
+          <orig><foreign xml:lang="grc">xpiani</foreign></orig>
           <reg>christiani</reg>
         </choice>
         accedere ad
@@ -1642,7 +1642,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>sacrificium</reg>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc"/>xpi</orig>
+          <orig><foreign xml:lang="grc">xpi</foreign></orig>
           <reg>christi</reg>
         </choice>
         . quia ual
@@ -1679,7 +1679,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         Semel uero natus est
         <choice>
-          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign>s</orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>s</orig>
           <reg>christus</reg>
         </choice>
         <lb n="111" />
@@ -1886,7 +1886,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>omnibus</reg>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign>anis</orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>anis</orig>
           <reg>christianis</reg>
         </choice>
         custodienda
@@ -2021,7 +2021,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="132" />
         qui ueritatem diligit:
         <choice>
-          <orig><orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign></orig>m</orig>
+          <orig><orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign></orig>m</orig>
           <reg>christum</reg>
         </choice>
         sequitur qui dixit. ego sum uia
@@ -2067,7 +2067,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="136" />
         fratres quia nichil est tam necesse homini
         <choice>
-          <orig><orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign></orig>ano</orig>
+          <orig><orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign></orig>ano</orig>
           <reg>christiano</reg>
         </choice>
         scire
@@ -3760,7 +3760,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         nos
         <lb n="285" />
         <choice>
-          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign>s</orig>
+          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>s</orig>
           <reg>christus</reg>
         </choice>
         qui est uera sapientia uera que uita: qui uiuit cum

--- a/edition.xml
+++ b/edition.xml
@@ -2646,7 +2646,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <pb n="16v" facs="data/images/fol_5v.png" />
 
         <lb n="183" />
-        Intellego me intellegere uelle:
+        <add place="left">Intellego me </add><add place="above">in</add>tellegere uelle:
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
@@ -3531,8 +3531,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         consentiat in desiderio suae naturae. ne quid in
         <lb n="262" />
-        <orig>decens</orig>
-        <corr>do<add>e</add>cens</corr>
+        <choice>
+          <orig>do<add place="above">e</add>cens</orig>
+          <reg>decens</reg>
+        </choice>
         fiat in officio suae carnis alicubi; Sicut
         <choice>
           <orig>enī</orig>
@@ -3576,7 +3578,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <orig>aerē</orig>
+          <orig><add place="above">a</add>erē</orig>
           <reg>aerem</reg>
         </choice>
         <lb n="265" />

--- a/edition.xml
+++ b/edition.xml
@@ -302,7 +302,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
           maria uirgine
           <choice>
-            <orig>p</orig>
+            <orig>p&#x0331;</orig>
             <reg>pro</reg>
           </choice>
           salute mundi. sed tamen
@@ -312,7 +312,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           </choice>
         <lb n="4" />
           <choice>
-            <orig>p</orig>
+            <orig>p&#x0331;</orig>
             <reg>pro</reg>
           </choice>
         huius diei sollempnitate. uestras mentes aliqua spirita
@@ -359,7 +359,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         non
         <choice>
-          <orig>p</orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         <lb n="8" />

--- a/edition.xml
+++ b/edition.xml
@@ -1058,14 +1058,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <choice>
           <abbr>feciss&amp;</abbr>
           <expan>fecisset</expan>
-        <choice> 
+        </choice> 
         si
         <lb n="62" />
         ante non 
         <choice>
           <abbr>ess&amp;</abbr>
           <expan>esset</expan>
-        <choice>; 
+        </choice>; 
         Sed erat
         <choice>
           <orig>semp&#x0331;:</orig>
@@ -1085,7 +1085,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <choice>
           <abbr>hab&amp;</abbr>
           <expan>habet</expan>
-        <choice>
+        </choice>
         <choice>
            <orig>semp&#x0331;</orig>
            <reg>semper</reg>

--- a/edition.xml
+++ b/edition.xml
@@ -369,16 +369,19 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>patrem</reg>
         </choice>
         <choice>
-          <orig>semp</orig>
+          <orig>semp&#x0331;</orig>
           <reg>semper</reg>
         </choice>
         in diuinitate: sed
-          <abbr>ess<am>
+          <abbr>ess&amp;</abbr>
+<!--Here I replaced this code:
+          <am>
             <g ref="amp"/>
-          </am></abbr>
-          <expan>ess<ex>et</ex></expan>
+          </am>
+    with the character sequence &amp; (seen above). This a different way to represent an ampersand according to TEI standards, since the last one was not properly rendering. I have made similar changes in following lines on this document.-->
+          <expan>esset</expan>
+<!--I also removed the <ex> (editorial expansion) tags; I can replace them if needed, but this looks like a normal abbreviation (cf. Cappelli pg. 113)-->
         aliquod
-
   <pb n="13v" facs="013v.jpg"/>
       <lb n="9" />
         tempus
@@ -386,7 +389,11 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>antequā</orig>
           <reg>antequam</reg>
         </choice>
-        natus ess<g ref="amp"/>
+        natus 
+        <choice>
+          <orig>ess&amp;</orig>
+          <reg>esset</reg>
+        </choice>
         ex patre; Audiamus nunc
         <choice>
           <orig>sc<g ref="#m_macron"/></orig>
@@ -397,19 +404,18 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>euuangeliū</orig>
           <reg>euuangelium</reg>
         </choice>
-        quomodo tales
+        quomodo tales 
+        h<add place="above">
+          <orig>a</orig>
+          <add>e</add>
+        </add>betes 
+<!--changed this from a choice tag to an <add> tag in the hopes that both the "a" and "e" will be present on the document, the "e" above the "a," just as in the original.-->
+        superat
         <choice>
-          <orig>habetes</orig>
-          <corr>h<add>e</add>betes</corr>
+          <orig>&amp;stultitiā</orig>
+          <reg>et stultitiam</reg>
         </choice>
-        <choice>
-          <orig>&amp;</orig>
-          <reg>et</reg>
-        </choice>
-        <choice>
-          <orig>stultitiā</orig>
-          <reg>stultitiam</reg>
-        </choice>
+<!--combined two different choice tags, one for ampersand and one for stultitia, into a single choice tag so that the text would render with no space in between, as in the original.-->
         <choice>
           <orig>eō</orig>
           <reg>eorum</reg>
@@ -417,7 +423,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="11" />
         facile confundit: Iudei
         <choice>
-          <orig>namq</orig>
+          <orig>namq:</orig>
           <reg>namque</reg>
         </choice>
         interrogauerunt
@@ -434,10 +440,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         qui
         <choice>
-          <orig>&amp;</orig>
-          <reg>et</reg>
+          <orig>&amp;loquor</orig>
+          <reg>et loquor</reg>
         </choice>
-        loquor uobis;
+        uobis;
       <lb n="13" />
         Audistis fratres
         <choice>

--- a/edition.xml
+++ b/edition.xml
@@ -2302,7 +2302,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         loquitur
         <choice>
           <abbr>p&#x0331;</abbr>
-          <expan>per</abbr>
+          <expan>per</expan>
         </choice>
         <choice>
           <abbr>p&#x0331;phetam</abbr>

--- a/edition.xml
+++ b/edition.xml
@@ -1900,7 +1900,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>pacē</orig>
           <reg>pacem</reg>
         </choice>
-        <g ref="amp"/>
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
         <choice>
           <orig>ueritatē</orig>
           <reg>ueritatem</reg>
@@ -1912,7 +1915,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>dominus</reg>
         </choice>
         <choice>
-           <orig><g ref="#d_macron"/>s</orig>
+           <orig>d<g ref="#s_macron"/></orig>
            <reg>deus</reg>
          </choice>
         <choice>
@@ -1924,7 +1927,11 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>pacē</orig>
           <reg>pacem</reg>
         </choice>
-        diligit: <g ref="amp"/>
+        diligit: 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
         <choice>
           <orig>ueritatē</orig>
           <reg>ueritatem</reg>
@@ -1936,36 +1943,58 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="127" />
         placat
         <choice>
-          <orig>sibim<g ref="amp"/></orig>
+          <orig>sibim&amp;</orig>
           <reg>sibimet</reg>
         </choice>
-        ipsi <g ref="amp"/> homines non offendit nec
+        ipsi 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        homines non offendit nec
         <choice>
           <orig>aliquē</orig>
           <reg>aliquem</reg>
         </choice>
         decipit;
         <lb n="128" />
-        Qui lites <g ref="amp"/>
+        Qui lites 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
         <choice>
           <orig>discordiā</orig>
           <reg>discordiam</reg>
         </choice>
         amat filius diaboli est qui mendacium
         <lb n="129" />
-        <g ref="amp"/>
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
         <choice>
           <orig>fraudē</orig>
           <reg>fraudem</reg>
         </choice>
          amat
-         <choice>
+        <choice>
            <orig>diabolū</orig>
            <reg>diabolum</reg>
-         </choice>
-          sequitur qui est mendax <g ref="amp"/> pater
+        </choice>
+        sequitur qui est mendax 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        pater
         <lb n="130" />
-        mendacii <g ref="amp"/> nihil agit nisi decipit quos potest; Nam de
+        mendacii 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        nihil agit nisi decipit quos potest; Nam de
         <lb n="131" />
         pacificis ait
         <choice>
@@ -1978,10 +2007,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
            <reg>quoniam</reg>
          </choice> filii dei
          <choice>
-           <orig>uocabun<g ref="#t_macron"/>.</orig>
-           <reg>uocabuntur.</reg>
-         </choice>
-        <g ref="amp"/> homo
+           <orig>uocabun<g ref="#t_macron"/></orig>
+           <reg>uocabuntur</reg>
+         </choice>.
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        homo
         <lb n="132" />
         qui ueritatem diligit:
         <choice>
@@ -1990,21 +2023,39 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         sequitur qui dixit. ego sum uia
         <lb n="133" />
-        <g ref="amp"/> ueritas. <g ref="amp"/> uita; Breuiter nunc
         <choice>
-          <orig>dici<g ref="#m_macron"/>.</orig>
-          <reg>dicimus.</reg>
-        </choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        ueritas. 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        uita; Breuiter nunc
+        <choice>
+          <orig>dici<g ref="#m_macron"/></orig>
+          <reg>dicimus</reg>
+        </choice>.
         quia nemo sine pace.
         <lb n="134" />
-        <g ref="amp"/> sine ueritate uiuens in hoc mundo habebit mansionem
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        sine ueritate uiuens in hoc mundo habebit mansionem
         <lb n="135" />
         nisi
         <choice>
           <orig>cū</orig>
           <reg>cum</reg>
         </choice>
-        diabulo <g ref="amp"/> angelis
+        diabulo 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        angelis
         <choice>
           <orig>eī</orig>
           <reg>eius</reg>
@@ -2032,7 +2083,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
            <orig>omnipotentē</orig>
            <reg>omnipotentem</reg>
          </choice>
-        uera fide. <g ref="amp"/> anima
+        uera fide. 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        anima
         <lb n="138" />
         ipsius ut intellegat cur ipse sit homo
         <choice>
@@ -2041,9 +2097,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         in terra. ad quit
         <lb n="139" />
-        creatus. <g ref="amp"/> ad quit
+        creatus. 
         <choice>
-          <orig><g ref="#p_macron"/>ueniat</orig>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        ad quit
+        <choice>
+          <orig>p&#x0331;ueniat</orig>
           <reg>perueniat</reg>
         </choice>
         in fine. sed quia sepius
@@ -2053,14 +2114,16 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         diximus
         <lb n="140" />
-        uobis de deo <g ref="amp"/> de fide catholica habundanter: uolumus
+        uobis de deo 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        de fide catholica habundanter: uolumus
         <lb n="141" />
         modo uobis dicere de humana anima breuiter si possumus;
         <lb n="142" />
-        Nichil aliquid magis homini in hac
-          mortali<add>t</add>ate
-          <!-- TODO: Check this!!! -->
-        uiuenti
+        Nichil aliquid magis homini in hac mortali<add place="above">t</add>ate uiuenti
         <lb n="143" />
         <choice>
           <orig>necessariū</orig>
@@ -2075,22 +2138,25 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>d<g ref="#m_macron"/></orig>
           <reg>deum</reg>
         </choice>
-        <g ref="amp"/>
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
         <choice>
           <orig>animā;</orig>
           <reg>animam</reg>
         </choice>
         Naturale
         <choice>
-          <orig>deniq</orig>
+          <orig>deniq:</orig>
           <reg>denique</reg>
         </choice>
         <lb n="144" />
         homini est bonum amare; Quid est
         <choice>
-          <orig>bonū.</orig>
-          <reg>bonum.</reg>
-        </choice>
+          <orig>bonū</orig>
+          <reg>bonum</reg>
+        </choice>.
          nisi
          <choice>
            <orig>d<g ref="#s_macron"/></orig>
@@ -2110,9 +2176,13 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="146" />
         poterit; Amor huius boni non nisi in anima esse poterit;
         <lb n="147" />
-        <g ref="amp"/> haec sola anima nobilis est
         <choice>
-          <orig>quē</orig>
+          <orig>&amp;</orig>
+          <reg>Et</reg>
+        </choice> 
+        haec sola anima nobilis est
+        <choice>
+          <orig>que</orig>
           <reg>quae</reg>
         </choice>
         illum amat a quo est quod
@@ -2122,31 +2192,39 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>imaginē.</orig>
           <reg>imaginem.</reg>
         </choice>
-        <g ref="amp"/> simili
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        simili
         <lb n="149" />
         tudinem
         <choice>
-          <orig>haber<g ref="amp"/></orig>
+          <orig>haber&amp;</orig>
            <reg>haberet</reg>
          </choice>
          <choice>
-           <orig>inpressā.</orig>
-           <reg>inpressam.</reg>
-         </choice>
-        <g ref="amp"/> digna
+           <orig>inpressā</orig>
+           <reg>inpressam</reg>
+         </choice>.
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        digna
         <choice>
           <orig>di</orig>
           <reg>dei</reg>
         </choice>
         <choice>
-          <orig>ess<g ref="amp"/></orig>
+          <orig>ess&amp;</orig>
           <reg>esset</reg>
         </choice>
          habitatione;
         <choice>
-            <orig>O<g ref="#m_macron"/>s</orig>
-            <reg>Omnes</reg>
-          </choice>
+          <orig>O<g ref="#m_macron"/>s</orig>
+          <reg>Omnes</reg>
+        </choice>
         <lb n="150" />
         <choice>
           <orig>enī</orig>
@@ -2157,6 +2235,995 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>dō</orig>
           <reg>deo</reg>
         </choice>
+
+<!--Insert lines 151-239 here-->
+
+<lb n="151" />
+        sit condita nec
+        <choice>
+          <abbr>parte<macron/></abbr>
+          <expan>partem</expan>
+        </choice>
+        <choice>
+          <abbr>ea<macron/></abbr>
+          <expan>eam</expan>
+        </choice>
+        <choice>
+          <abbr>e<macron/>s</abbr>
+          <expan>esse</expan>
+        </choice>
+        dei naturae; Quia si ex dei
+
+        <lb n="152" />
+        ess<g ref="amp"/> natura assumpta. peccare non poss<g ref="amp"/>; Unde ait salomon:
+
+        <lb n="153" />
+        reuertatur puluis in
+        <choice>
+          <abbr>terra<macron/></abbr>
+          <expan>terram</expan>
+        </choice>
+        <choice>
+          <abbr>sua<macron/></abbr>
+          <expan>suam</expan>
+        </choice>
+        unde erat:
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>sp<macron/>s</abbr>
+          <expan>spiritus</expan>
+        </choice>
+        redeat ad
+        <choice>
+          <abbr>dm<macron/></abbr>
+          <expan>deum</expan>
+        </choice>
+
+        <pb n="16r" facs="data/images/fol_5v.png" />
+
+        <lb n="154" />
+        qui dedit illum; Et
+        <choice>
+          <abbr>dn<macron/>s</abbr>
+          <expan>dominus</expan>
+        </choice>
+        loquitur per
+        <choice>
+          <abbr>p<macron/>phetam</abbr>
+          <expan>prophetam</expan>
+        </choice>
+        ; Omnem flatum
+
+        <lb n="155" />
+        ego feci:
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>Et</expan>
+        </choice>
+        <choice>
+          <abbr>iteru<macron/></abbr>
+          <expan>iterum</expan>
+        </choice>
+        <choice>
+          <abbr>scriptu<macron/></abbr>
+          <expan>scriptum</expan>
+        </choice>
+        est. qui fingit
+        <choice>
+          <abbr>sp<macron/>m</abbr>
+          <expan>spiritum</expan>
+        </choice>
+        hominis in ipso; Et
+
+        <lb n="156" />
+        <choice>
+          <abbr>apts</abbr>
+          <expan>apostolus</expan>
+        </choice>
+        paulus.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        ipse d<g ref="amp"/> omnibus
+        <choice>
+          <abbr>uita<macron/></abbr>
+          <expan>uitam</expan>
+        </choice>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>sp<macron/>m</abbr>
+          <expan>spiritum</expan>
+        </choice>
+        ; Triplex est enim
+
+        <lb n="157" />
+        animae ut philosophi uolunt natura: Est in ea quaedam
+
+        <lb n="158" />
+        pars concupisscibilis. alia rationabilis. tertia irascibilis; Duas
+
+        <lb n="159" />
+        enim habent
+        <choice>
+          <abbr>haru<macron/></abbr>
+          <expan>harum</expan>
+        </choice>
+        partes
+        <choice>
+          <abbr>nobiscu<macron/></abbr>
+          <expan>nobiscum</expan>
+        </choice>
+        bestiae
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        animalia com
+
+        <lb n="160" />
+        munes id est
+        <choice>
+          <abbr>concupiscentia<macron/></abbr>
+          <expan>concupiscentiam</expan>
+        </choice>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        iram; Homo solus inter in
+
+        <lb n="161" />
+        rationabiles ratione uig<g ref="amp"/>. consilio ual<g ref="amp"/> intellegentia ante
+
+        <lb n="162" />
+        cellit; Concupiscentia data est homini ad cupiscenda quae
+
+        <lb n="163" />
+        sunt utilia.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        quae sibi ad
+        <choice>
+          <abbr>salute<macron/></abbr>
+          <expan>salutem</expan>
+        </choice>
+        <choice>
+          <abbr>p<macron/>ficiant</abbr>
+          <expan>proficiant</expan>
+        </choice>
+        <choice>
+          <abbr>sempiterna<macron/></abbr>
+          <expan>sempiternam</expan>
+        </choice>
+        ; Si uero
+
+        <lb n="164" />
+        corrumpitur.
+        <choice>
+          <abbr>nascitu<macron/></abbr>
+          <expan>nascitur</expan>
+        </choice>
+        ex ea gastrimargia fornicatio.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+
+        <lb n="165" />
+        philargiria; Ira data est ad uitia cohibenda ne impiis id est
+
+        <lb n="166" />
+        peccatis homo seruiat dominis quia iuxta
+        <choice>
+          <abbr>dn<macron/>i</abbr>
+          <expan>domini</expan>
+        </choice>
+        uocem qui
+
+        <lb n="167" />
+        facit
+        <choice>
+          <abbr>peccatu<macron/></abbr>
+          <expan>peccatum</expan>
+        </choice>
+        seruus est peccati; Ex qua corrupta
+        <choice>
+          <abbr>p<macron/>cedit</abbr>
+          <expan>procedit</expan>
+        </choice>
+
+        <lb n="168" />
+        tristitia.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        accidia; Ratio data est ut diximus omnem
+
+        <lb n="169" />
+        hominis
+        <choice>
+          <abbr>uita<macron/></abbr>
+          <expan>uitam</expan>
+        </choice>
+        regere
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        gubernare; Ex qua si corrumpitur
+
+        <lb n="170" />
+        <choice>
+          <abbr>orit<macron/></abbr>
+          <expan>oritur</expan>
+        </choice>
+        .
+        <choice>
+          <abbr>sup<macron/>bia</abbr>
+          <expan>superbia</expan>
+        </choice>
+        .
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        caeno doxia; Paruulis
+        <choice>
+          <abbr>eni<macron/></abbr>
+          <expan>enim</expan>
+        </choice>
+        ratio crescit non
+
+        <lb n="171" />
+        anima.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>p<macron/>ficiendo</abbr>
+          <expan>proficiendo</expan>
+        </choice>
+        ad uirtutem non maior fit. sed melior
+
+        <lb n="172" />
+        nec
+        <choice>
+          <abbr>corporale<macron/></abbr>
+          <expan>corporalem</expan>
+        </choice>
+        recipit
+        <choice>
+          <abbr>quantitate<macron/></abbr>
+          <expan>quantitatem</expan>
+        </choice>
+        ; Hab<g ref="amp"/> igitur anima in
+
+        <lb n="173" />
+        sua natura ut
+        <choice>
+          <abbr>dixim<macron/></abbr>
+          <expan>diximus</expan>
+        </choice>
+        <choice>
+          <abbr>imagine<macron/></abbr>
+          <expan>imaginem</expan>
+        </choice>
+        <choice>
+          <abbr>sc<macron/>ae</abbr>
+          <expan>sanctae</expan>
+        </choice>
+        trinitatis. in eo quod in
+
+        <lb n="174" />
+        tellegentiam
+        <choice>
+          <abbr>uoluntate<macron/></abbr>
+          <expan>uoluntatem</expan>
+        </choice>
+        :
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>memoria<macron/></abbr>
+          <expan>memoriam</expan>
+        </choice>memoria[m] hab<g ref="amp"/>; Una est
+
+        <lb n="175" />
+        <choice>
+          <abbr>eni<macron/></abbr>
+          <expan>enim</expan>
+        </choice>
+        anima quae mens dicitur. una uita.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        una substantia.
+
+        <lb n="176" />
+        quae haec tria hab<g ref="amp"/> in se: sed
+        <choice>
+          <abbr>h<macron/>ec</abbr>
+          <expan>haec</expan>
+        </choice>
+        tria non sunt tres uitae
+
+        <lb n="177" />
+        sed una uita; Nec tres
+        <choice>
+          <abbr>substanti<macron/>e</abbr>
+          <expan>substantiae</expan>
+        </choice> sed una; Quod uero ani
+
+        <lb n="178" />
+        ma uel mens uel uita. uel substantia dicitur. ad se ipsam
+
+        <lb n="179" />
+        <choice>
+          <abbr>dicit<macron/></abbr>
+          <expan>dicitur</expan>
+        </choice>
+        ; Quod uero memoria. uel intellegentia. uel uolun
+
+        <lb n="180" />
+        tas dicitur. ad aliquid relatiue dicitur; Nam in his
+        <choice>
+          <abbr>trib<macron/></abbr>
+          <expan>tribus</expan>
+        </choice>
+
+        <lb n="181" />
+        unitas
+        <choice>
+          <abbr>quaeda<macron/></abbr>
+          <expan>quadam</expan>
+        </choice>
+        est. quia quicquid ad se ipsa singula
+        <choice>
+          <abbr>dicunt<macron/></abbr>
+          <expan>dicuntur</expan>
+        </choice>
+
+        <lb n="182" />
+        <g ref="amp"/>iam simul: non pluraliter sed singulariter dicuntur;
+
+        <pb n="16v" facs="data/images/fol_5v.png" />
+
+        <lb n="183" />
+        <---LINE STARTS A BIT BEFORE NORMAL - EXTRA TEXT ADDED--!>
+        Intellego me intellegere uelle:
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        meminisse;
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>Et</expan>
+        </choice>
+        uolo me intellegere.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        me
+
+        <lb n="184" />
+        minisse.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        uelle; Et minime intellegere: uel uelle. uel memi
+
+        <lb n="185" />
+        nisse.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        sic in singulis singula capiuntur;
+        <choice>
+          <abbr>Considerem<macron/></abbr>
+          <expan>Consideremus</expan>
+        </choice>
+        <choice>
+          <abbr>aute<macron/></abbr>
+          <expan>autem</expan>
+        </choice>
+
+        <lb n="186" />
+        miram uelocitatem animae in formandis rebus. quae
+        <choice>
+          <abbr>p<macron/>cipit</abbr>
+          <expan>percipit</expan>
+        </choice>
+
+        <lb n="187" />
+        <choice>
+          <abbr>p<macron/></abbr>
+          <expan>per</expan>
+        </choice>
+        carnales sensus a
+        <choice>
+          <abbr>quib<macron/></abbr>
+          <expan>quibus</expan>
+        </choice>
+        quasi
+        <choice>
+          <abbr>p<macron/></abbr>
+          <expan>per</expan>
+        </choice>
+        quosdam nuntios quicquid
+
+        <lb n="188" />
+        rerum
+        <choice>
+          <abbr>uisibiliu<macron/></abbr>
+          <expan>uisibilium</expan>
+        </choice>
+        <choice>
+          <abbr>cognitaru<macron/></abbr>
+          <expan>cognitarum</expan>
+        </choice>
+        uel
+        <choice>
+          <abbr>incognitaru<macron/></abbr>
+          <expan>incognitarum</expan>
+        </choice>
+        <choice>
+          <abbr>p<macron/>cipit</abbr>
+          <expan>percipit</expan>
+        </choice>
+        : mox
+
+        <lb n="189" />
+        in se ipsa
+        <choice>
+          <abbr>earu<macron/></abbr>
+          <expan>earum</expan>
+        </choice>
+        ineffabili celeritate format figuras. for
+
+        <lb n="190" />
+        matasque in suo thesauro memoriae recondit; Sicut
+
+        <lb n="191" />
+        enim qui romam
+        <choice>
+          <abbr>quonda<macron/></abbr>
+          <expan>quondam</expan>
+        </choice>
+        uidit.
+        <choice>
+          <abbr>iteru<macron/></abbr>
+          <expan>iterum</expan>
+        </choice>
+        <choice>
+          <abbr>cu<macron/></abbr>
+          <expan>cum</expan>
+        </choice>
+        nomen audierit
+
+        <lb n="192" />
+        romam fingit in animo suo
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        format qualis sit; Et ad
+
+        <lb n="193" />
+        huc mirabilius est quod incognitae res si lectae uel audit[a]e
+
+        <lb n="194" />
+        erunt in
+        <choice>
+          <abbr>auri:</abbr>
+          <expan>aurbus</expan>
+        </choice>
+        <choice>
+          <abbr>anim<macron/></abbr>
+          <expan>animae</expan>
+        </choice>
+        : statim format
+        <choice>
+          <abbr>figura<macron/></abbr>
+          <expan>figuram</expan>
+        </choice>
+        <choice>
+          <abbr>ignote</abbr>
+          <expan>ignotae</expan>
+        </choice>
+
+        <lb n="195" />
+        rei; Ex notis enim speciebus fingit ignota: Ex qua ueloci
+
+        <lb n="196" />
+        tate animae quo in se sic omnia fingit audita: aut uisa.
+
+        <lb n="197" />
+        aut sensa: aut odorata: aut gustata.
+        <choice>
+          <abbr>iteru<macron/></abbr>
+          <expan>iterum</expan>
+        </choice>
+        inuenta recog
+
+        <lb n="198" />
+        noscit siue curando siue non curando;
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>Et</expan>
+        </choice>
+        tante mobilita
+
+        <lb n="199" />
+        tis est ut nec
+        <choice>
+          <abbr>cu</abbr>
+          <expan>cum</expan>
+        </choice>
+        sopita est conquiescat;
+        <choice>
+          <abbr>Tante<macron/></abbr>
+          <expan>Tantae</expan>
+        </choice>
+        celeritatis
+
+        <lb n="200" />
+        ut uno temporis puncto
+        <choice>
+          <abbr>caelu</abbr>
+          <expan>caelum</expan>
+        </choice>
+        conlustr<g ref="amp"/> si uelit; Maria
+
+        <lb n="201" />
+        <choice>
+          <abbr>p>macron/>uolat</abbr>
+          <expan>peruolat</expan>
+        </choice>
+        . terras
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        urbes
+        <choice>
+          <abbr>p<macron/>agr&amp;</abbr>
+          <---IS THIS CORRECT?-->
+          <expan>peragret</expan>
+        </choice>
+        . omnia in conspectu sibi
+
+        <lb n="202" />
+        cogitando constituens; Sed
+        <choice>
+          <abbr>cu<macron/></abbr>
+          <expan>cum</expan>
+        </choice>
+        de roma cogitat. non eo
+
+        <lb n="203" />
+        momento de hierusalem potest cogitare; Uel
+        <choice>
+          <abbr>cu<macron/></abbr>
+          <expan>cum</expan>
+        </choice>
+        de qua
+
+        <lb n="204" />
+        lib<g ref="amp"/> una
+        <choice>
+          <abbr>remeditat<macron/></abbr>
+          <expan>remeditatur</expan>
+        </choice>
+        non potest eo momento de
+        <choice>
+          <abbr>plurib:</abbr>
+          <expan>pluribus</expan>
+        </choice>
+
+        <lb n="205" />
+        meditari. sed hoc
+        <choice>
+          <abbr>unu<macron/></abbr>
+          <expan>unum</expan>
+        </choice>
+        illi tunc presens est donec uel
+
+        <lb n="206" />
+        citius uel tardius
+        <choice>
+          <abbr>he<macron/>c</abbr>
+          <expan>haec</expan>
+        </choice>
+        cogitatio recedat
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        alia
+        <choice>
+          <abbr>sup<macron/></abbr>
+          <expan>super</expan>
+        </choice>
+
+        <lb n="207" />
+        ueniat; At
+        <choice>
+          <abbr>di<macron/></abbr>
+          <expan>dei</expan>
+        </choice>
+        omnipotentis
+        <choice>
+          <abbr>nature<macron/></abbr>
+          <expan>naturae</expan>
+        </choice>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        ineffabili cog
+
+        <lb n="208" />
+        nitioni omnia simul sunt presentia.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>semp<macron/></abbr>
+          <expan>semper</expan>
+        </choice>
+        <choice>
+          <abbr>p<macron/>sentia</abbr>
+          <expan>praesentia</expan>
+        </choice>
+        .
+
+        <lb n="209" />
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>numqua</abbr>
+          <expan>numquam</expan>
+        </choice>
+        recedentia.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        hoc est quod dicitur quod
+
+        <lb n="210" />
+        <choice>
+          <abbr>d<macron/>s</abbr>
+          <expan>deus</expan>
+        </choice>
+        <choice>
+          <abbr>ubiq:</abbr>
+          <expan>ubique</expan>
+        </choice>
+        totus est. quia quae sunt. uel fuerunt. uel
+
+        <lb n="211" />
+        quae futura sunt: simul omnia non semel sed semper
+
+        <pb n="17r" facs="data/images/fol_5v.png" />
+
+        <lb n="212" />
+        presentia hab<g ref="amp"/>; Anima
+        <choice>
+          <abbr>namq:</abbr>
+          <expan>namque</expan>
+        </choice>
+        corporis uita est anime
+
+        <lb n="213" />
+        uero uita
+        <choice>
+          <abbr>d<macron/>s</abbr>
+          <expan>deus</expan>
+        </choice>
+        est; Dum anima corpus deserit: moritur;
+
+        <lb n="214" />
+        Animae uero mors est dum eam
+        <choice>
+          <abbr>d<macron/>s</abbr>
+          <expan>deus</expan>
+        </choice>
+        deserit dono suae
+
+        <lb n="215" />
+        gratiae.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        ob
+        <choice>
+          <abbr>magnitude<macron/></abbr>
+          <expan>magnitudem</expan>
+        </choice>
+        scelerum moritur meliore
+
+        <lb n="216" />
+        sui parte.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        erit semiuiua.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        hoc erit si concupiscentia
+
+        <lb n="217" />
+        uel ira. plus dominabitur in homine quam ratio in qua
+
+        <lb n="218" />
+        sola precellit animantibus; Duabus uero dignitatibus
+
+        <lb n="219" />
+        a creatore anima in sua natura glorificata est. id est
+
+        <lb n="220" />
+        aeternitate.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        beatitudine; Sed cum libero arbitrio
+
+        <lb n="221" />
+        maligno
+        <choice>
+          <abbr>sp<macron/>u</abbr>
+          <expan>spiritu</expan>
+        </choice>
+        instigante deprauata est, beatitudinem
+        <choice>
+          <abbr>p<macron/>di</abbr>
+          <expan>perdi</expan>
+        </choice> p[er]di
+
+        <lb n="222" />
+        dit.
+        <choice>
+          <abbr>aeternitate<macron/></abbr>
+          <expan>aeternitatem</expan>
+        </choice>
+        <choice>
+          <abbr>p<macron/>dere</abbr>
+          <expan>perdere</expan>
+        </choice> non potuit; Cuius pulchritudo
+
+        <lb n="223" />
+        <choice>
+          <abbr>uirtu<macron/></abbr>
+          <expan>uirtus</expan>
+        </choice>
+        est.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>ei<macron/></abbr>
+          <expan>eius</expan>
+        </choice>
+        deformitas
+        <choice>
+          <abbr>uitiu<macron/></abbr>
+          <expan>uitium</expan>
+        </choice>
+        ; Cuius excellentiores
+
+        <lb n="224" />
+        uirtutes quattuor esse
+        <choice>
+          <abbr>manifestu<macron/></abbr>
+          <expan>manifestum</expan>
+        </choice>
+        est; Id est, prudentia
+
+        <lb n="225" />
+        quae
+        <choice>
+          <abbr>d<macron/>m</abbr>
+          <expan>deum</expan>
+        </choice>
+        intellegit
+        <choice>
+          <abbr>amandu<macron/></abbr>
+          <expan>amandum</expan>
+        </choice>
+        .
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        agenda uel non agenda
+
+        <lb n="226" />
+        discernit; Iustitia, qua
+        <choice>
+          <abbr>d<macron/>s</abbr>
+          <expan>deus</expan>
+        </choice>
+        colitur
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <abbr>amat<macron/></abbr>
+          <expan>amatur</expan>
+        </choice>
+        ,
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        recte
+        <choice>
+          <abbr>uiuit<macron/></abbr>
+          <expan>uiuitur</expan>
+        </choice>
+        ;
+
+        <lb n="227" />
+        Temperantia. qua
+        <choice>
+          <abbr>concupiscentia<macron/></abbr>
+          <expan>concupiscentiam</expan>
+        </choice>
+        uel iram gubernat;
+
+        <lb n="228" />
+        Fortitudo, qua
+        <choice>
+          <abbr>p<macron/></abbr>
+          <expan>pro</expan>
+        </choice>
+        dei amore fortiter omnia aduersa
+
+        <lb n="229" />
+        huius uitae constanti animo tolerat; Et hae quattuor
+
+        <lb n="230" />
+        uirtutes uno caritatis diademate ornantur: Haec est
+
+        <lb n="231" />
+        <choice>
+          <abbr>eni<macron/></abbr>
+          <expan>enim</expan>
+        </choice>
+        animae summa beatitudo.
+        <choice>
+          <abbr>eu<macron/></abbr>
+          <expan>eum</expan>
+        </choice>
+        diligere a quo est.
+
+        <lb n="232" />
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        socias suae beatitudinis diligere animas.
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        illis
+        <choice>
+          <abbr>p<macron/>desse</abbr>
+          <expan>prodesse</expan>
+        </choice>
+
+        <lb n="233" />
+        in
+        <choice>
+          <abbr>quant</abbr>
+          <expan>quantum</expan>
+        </choice>
+        ualeat; Hoc modo anima definiri potest.
+
+        <lb n="234" />
+        iuxta
+        <choice>
+          <abbr>su<macron/>e</abbr>
+          <expan>suae</expan>
+        </choice>
+        <choice>
+          <abbr>p<macron/>prietatem</abbr>
+          <expan>proprietatem</expan>
+        </choice>
+        <choice>
+          <abbr>natur<macron/>e</abbr>
+          <name></name>expan>naturae</expan>
+        </choice>
+        ; Anima est
+        <choice>
+          <abbr>sp<macron/>s</abbr>
+          <expan>spiritus</expan>
+        </choice>
+        intel
+
+        <lb n="235" />
+        lectualis. rationalis:
+        <choice>
+          <abbr>semp<macron/></abbr>
+          <expan>semper</expan>
+        </choice>
+        inmota
+        <choice>
+          <abbr>semp<macron/></abbr>
+          <expan>semper</expan>
+        </choice>
+        uiuens. bonae.
+
+        <lb n="236" />
+        <choice>
+          <abbr>maleq:<macron/></abbr>
+          <expan>maleque</expan>
+        </choice>
+        uoluntatis capax. sed
+        <choice>
+          <abbr>dm<macron/></abbr>
+          <expan>domini</expan>
+        </choice>
+        benignitate creatoris
+
+        <lb n="237" />
+        libero arbitrio nobilitata: sua uoluntate uitiata. dei
+
+        <lb n="238" />
+        gratia liberata in
+        <choice>
+          <abbr>quib:</abbr>
+          <expan>quibus</expan>
+        </choice> ipse
+        <choice>
+          <abbr>dn<macron/>s</abbr>
+          <expan>dominus</expan>
+        </choice>
+        uoluit. ad
+        <choice>
+          <abbr>regendu<macron/></abbr>
+          <expan>regendum</expan>
+        </choice>
+        <choice>
+          <abbr>mot<macron/></abbr>
+          <expan>motus</expan>
+        </choice>
+
+        <lb n="239" />
+        carnis creata: inuisibilis. incorporalis. sine pondere. sine
+
+<!--Conclude insertion of lines 151-239-->
+
         <lb n="240" />
         colore:
         <choice>

--- a/edition.xml
+++ b/edition.xml
@@ -246,6 +246,12 @@
             value="Q CHARACTER WITH A MACRON OVER IT"/>
         <mapping type="standard">q&#x00AF;</mapping>
     </char>
+    <char xml:id="r_rotunda_cut">
+        <localProp name="name"
+            value="R ROTUNDA WITH A CUT"/>
+        <mapping type="normalized">ꝵ</mapping>
+        <mapping type="diplomatic">ꝵ</mapping>
+    </char>
         </charDecl>
     </encodingDesc>
 		<revisionDesc>
@@ -483,7 +489,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
          </choice>
         qui est caritas
         <choice>
-          <orig>ambo&#xA75B;</orig>
+          <orig>ambo<g ref="#r_rotunda_cut"/></orig>
           <reg>amborum</reg>
         </choice>
         <choice>
@@ -1252,7 +1258,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         unus
         <choice>
-          <orig lang="GK">xps</orig>
+          <orig><foreign xml:lang="grc">xps</orig>
           <reg>christus</reg>
         </choice>
         ; Creaturae uero quas unus
@@ -1460,9 +1466,8 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         oculi
         <choice>
-          <abbr>eo</abbr>
+          <abbr>eo<g ref="#r_rotunda_cut"/></abbr>
           <expan>eorum</expan>
-        <!--PSI LOOKING SYMBOL? -->
         </choice>
         ne uideant: 
         <choice>
@@ -1471,9 +1476,8 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         dorsa
         <choice>
-          <abbr>eo</abbr>
+          <abbr>eo<g ref="#r_rotunda_cut"/></abbr>
           <expan>eorum</expan>
-        <!--PSI LOOKING SYMBOL? -->
         </choice>
         semper
 
@@ -1572,8 +1576,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>panem</expan>
         </choice>
         <choice>
-          <abbr>angelo</abbr>
-<!--Come back and add in rum character-->
+          <abbr>angelo<g ref="#r_rotunda_cut"/></abbr>
           <expan>angelorum</expan>
         </choice>
         qui de celo descendit. qui hodie
@@ -1618,7 +1621,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="106" />
         mus cum ad sacrificium
         <choice>
-          <orig lang="GK">xpi</orig>
+          <orig><foreign xml:lang="grc">xpi</orig>
           <reg>christi</reg>
         </choice>
         <choice>
@@ -1630,7 +1633,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="107" />
         hodie debent
         <choice>
-          <orig lang="GK">xpiani</orig>
+          <orig><foreign xml:lang="grc">xpiani</orig>
           <reg>christiani</reg>
         </choice>
         accedere ad
@@ -1639,7 +1642,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>sacrificium</reg>
         </choice>
         <choice>
-          <orig lang="GK">xpi</orig>
+          <orig><foreign xml:lang="grc">xpi</orig>
           <reg>christi</reg>
         </choice>
         . quia ual
@@ -3570,21 +3573,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>aerē</orig>
           <reg>aerem</reg>
         </choice>
-
-<!--Left off here!-->
-
         <lb n="265" />
-        <choice>
-          <orig>quē</orig>
-          <reg>quae</reg>
-        </choice>
-        sunt excellentiora mundi corpora corpus amminis
+        quae sunt excellentiora mundi corpora corpus amminis
         <lb n="266" />
         trat
         <choice>
-          <orig>suū;</orig>
+          <orig>suū</orig>
           <reg>suum</reg>
-        </choice>
+        </choice>;
         <choice>
           <orig>Omniū</orig>
           <reg>Omnium</reg>
@@ -3597,7 +3593,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="267" />
         quas ipsa in se acceptas specificat.
         <choice>
-          <orig>specificatas<g ref="#q_macron"/></orig>
+          <orig>specificatasq:</orig>
           <reg>specificatasque</reg>
         </choice>
         recondit;
@@ -3609,7 +3605,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         affectata erit
         <choice>
-          <orig>qualib<g ref="amp"/></orig>
+          <orig>qualib&amp;</orig>
           <reg>qualibet</reg>
         </choice>
         cogitatione.
@@ -3621,15 +3617,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         uis
         <choice>
-          <orig>a<g ref="#p_macron"/>tos</orig>
+          <orig>ap&#x0331;tos</orig>
           <reg>apertos</reg>
         </choice>
-        habeat oculos
-        <choice>
-          <orig>qūe</orig>
-          <reg>quae</reg>
-        </choice>
-        presto sunt non uidit.
+        habeat oculos quae presto sunt non uidit.
 
     <pb n="18r" facs="018r.jpg"/>
         <lb n="270" />
@@ -3642,24 +3633,29 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="271" />
         sentit; Modo corporis
         <choice>
-          <orig>dolori<g ref="#b_macron"/></orig>
+          <orig>dolorib:</orig>
           <reg>doloribus</reg>
         </choice>
          <choice>
-           <orig>condol<g ref="amp"/>.</orig>
+           <orig>condol&amp;</orig>
            <reg>condolet</reg>
-         </choice>
+         </choice>.
         modo letitia
         <lb n="272" />
         hilarescit. modo cognita recogitat. modo incognita
         <lb n="273" />
         scire quaerit. alia uult. alia non uult; Humane uero
         <lb n="274" />
-        animae pulchritudo est <g ref="amp"/> decus sapientiae studium:
+        animae pulchritudo est 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        decus sapientiae studium:
         <lb n="275" />
         non illa quae in terrenis
         <choice>
-          <orig>sol<g ref="amp"/></orig>
+          <orig>sol&amp;</orig>
           <reg>solet</reg>
         </choice>
         occupari negotiis. sed illa
@@ -3669,27 +3665,37 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>d<g ref="#s_macron"/></orig>
           <reg>deus</reg>
         </choice>
-        colitur. <g ref="amp"/> amatur; Ergo uera est sapientia
-        <lb n="277" />
-        nosse quae debeas. <g ref="amp"/> nota
+        colitur. 
         <choice>
-          <orig><g ref="#p_macron"/>ficere;</orig>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        amatur; Ergo uera est sapientia
+        <lb n="277" />
+        nosse quae debeas. 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        nota
+        <choice>
+          <orig>p&#x0331;ficere;</orig>
           <reg>perficere;</reg>
         </choice>
         Haec in uirgiliacis non
         <lb n="278" />
-        inuenietur mendaciis. sed in euuangelii affluenter rep-
+        inuenietur mendaciis. sed in euuangelii affluenter rep
         <lb n="279" />
         peritur ueritate; De uera
         <choice>
-          <orig>scilic<g ref="amp"/></orig>
+          <orig>scilic&amp;</orig>
           <reg>scilicet</reg>
         </choice>
         sapientia dicitur omnis
         <lb n="280" />
         sapientia a
         <choice>
-          <orig><g ref="#d_macron"/>no</orig>
+          <orig>d<g ref="#n_macron"/>o</orig>
           <reg>domino</reg>
         </choice>
         deo est; Pro inde omnis qui
@@ -3704,7 +3710,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>bea<g ref="#t_macron"/></orig>
           <reg>deatus</reg>
         </choice>
-        est; Unde iniob dicitur; Sapientia homi-
+        est; Unde iniob dicitur; Sapientia homi
         <lb n="282" />
         nis est pietas: recedere
         <choice>
@@ -3714,7 +3720,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         a malo scientia; Uera est
         <lb n="283" />
         <choice>
-          <orig>scilic<g ref="amp"/></orig>
+          <orig>scilic&amp;</orig>
           <reg>scilicet</reg>
         </choice>
          sapientia:
@@ -3727,15 +3733,19 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>uitā</orig>
           <reg>uitam</reg>
         </choice>
-        <g ref="amp"/> totis
         <choice>
-          <orig>uiri<g ref="#b_macron"/></orig>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        totis
+        <choice>
+          <orig>uirib:</orig>
           <reg>uiribus</reg>
         </choice>
         <lb n="284" />
         intendere. ut ad eam
         <choice>
-          <orig><g ref="#p_macron"/>uenire</orig>
+          <orig>p&#x0331;uenire</orig>
           <reg>peruenire</reg>
         </choice>
         mereatur. ad
@@ -3744,7 +3754,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>quam</reg>
         </choice>
         <choice>
-          <orig><g ref="#p_macron"/>ducat</orig>
+          <orig>p&#x0331;ducat</orig>
           <reg>perducat</reg>
         </choice>
         nos
@@ -3768,10 +3778,19 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>d<g ref="#s_macron"/></orig>
           <reg>deus</reg>
         </choice>
-           sine initio. <g ref="amp"/> nunc <g ref="amp"/> sine
+        sine initio. 
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice>
+        nunc
+        <choice>
+          <orig>&amp;</orig>
+          <reg>et</reg>
+        </choice> 
+        sine
         <lb n="287" />
-        fine. AMEN;
-
+        fine. A M E N;
       </ab>
     </div>
 	</body>

--- a/edition.xml
+++ b/edition.xml
@@ -987,16 +987,19 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>iniquitatē.</orig>
           <reg>iniquitatem</reg>
         </choice>
-        <g ref="amp"/>
         <choice>
-          <orig><g ref="#p_macron"/>dit</orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <orig>p&#x0331;dit</orig>
           <reg>perdit</reg>
         </choice>
         <choice>
           <orig>o<g ref="#m_macron"/>s</orig>
           <reg>omnes</reg>
         </choice>
-        qui loquun-
+        qui loquun
         <lb n="58" />
         tur
         <choice>
@@ -1010,53 +1013,90 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>illū;</orig>
           <reg>illium;</reg>
         </choice>
-          Et si factus
-          ess<g ref="amp"/>
-          <choice>
-            <orig>numquā</orig>
-            <reg>numquam</reg>
-          </choice>
-          ess<g ref="amp"/>
+        Et si factus
+        <choice>
+          <abbr>ess&amp;</abbr>
+          <expan>esset</expan>
+        </choice>
+        <choice>
+          <orig>numquā</orig>
+          <reg>numquam</reg>
+        </choice>
+        <choice>
+          <abbr>ess&amp;</abbr>
+          <expan>esset</expan>
+        </choice>
         <lb n="60" />
         <choice>
           <orig>o<g ref="#m_macron"/>ps</orig>
           <reg>omnipotens</reg>
         </choice>
         <choice>
-          <orig><g ref="#d_macron"/>s;</orig>
+          <orig>d<g ref="#s_macron"/>;</orig>
           <reg>deus;</reg>
         </choice>
-          <g ref="amp"/> si aliquis insanus existimat quod
-          <choice>
-            <orig>d<g ref="#s_macron"/></orig>
-            <reg>deus</reg>
-          </choice>
-        seipsum
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        si aliquis insanus existimat quod
+        <choice>
+          <orig>d<g ref="#s_macron"/></orig>
+          <reg>deus</reg>
+        </choice>
+        se ipsum
         <lb n="61" />
-        feciss<g ref="amp"/>:
+        <choice>
+          <abbr>feciss&amp;</abbr>
+          <expan>fecisset</expan>
+        <choice>:
         tunc interrogemus quomodo se
         <choice>
           <orig>ipsū</orig>
           <reg>ipsum</reg>
         </choice>
-        feciss<g ref="amp"/> si
-        <lb n="62" />
-        ante non ess<g ref="amp"/>;Sed erat
         <choice>
-          <orig>sem<g ref="#p_macron"/>:</orig>
+          <abbr>feciss&amp;</abbr>
+          <expan>fecisset</expan>
+        <choice> 
+        si
+        <lb n="62" />
+        ante non 
+        <choice>
+          <abbr>ess&amp;</abbr>
+          <expan>esset</expan>
+        <choice>; 
+        Sed erat
+        <choice>
+          <orig>semp&#x0331;:</orig>
           <reg>semper:</reg>
         </choice>
-        <g ref="amp"/> est,
-        <g ref="amp"/> erit; Et ipse solus
-        <lb n="63" />
-        hab<g ref="amp"/>
         <choice>
-           <orig>sem<g ref="#p_macron"/></orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        est,
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        erit; Et ipse solus
+        <lb n="63" />
+        <choice>
+          <abbr>hab&amp;</abbr>
+          <expan>habet</expan>
+        <choice>
+        <choice>
+           <orig>semp&#x0331;</orig>
            <reg>semper</reg>
          </choice>
-        esse in se <g ref="amp"/>
+        esse in se 
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        <choice>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         se;
@@ -1072,9 +1112,21 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="64" />
         nequimus de eo digne nec cogitare nec loqui: quia est
         <lb n="65" />
-        inscrutabilis <g ref="amp"/>
-        ineffabilis. <g ref="amp"/>
-        angelis <g ref="amp"/>
+        inscrutabilis 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        ineffabilis. 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        angelis 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         hominibus; Trinitas
         <lb n="66" />
         est
@@ -1088,7 +1140,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         pater ex quo omnia: filius
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         quem omnia
@@ -1104,28 +1156,45 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
     <pb n="14v" facs="014v.jpg"/>
         <lb n="67" />
         in quo omnia: sed filius solus incarnatus est.
-        <g ref="amp"/> hodie natus
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        hodie natus
         <lb n="68" />
         sine terreno patre qui ex patre
         <choice>
-          <orig>sem<g ref="#p_macron"/></orig>
+          <orig>semp&#x0331;</orig>
           <reg>semper</reg>
         </choice>
         natus est sine matre;
         <lb n="69" />
-        Non hab<g ref="amp"/>
+        Non 
+        <choice>
+          <abbr>hab&amp;</abbr>
+          <expan>habet</expan>
+        </choice>
         <choice>
           <orig>initiū</orig>
           <reg>initium</reg>
         </choice>
         in diuinitate;
-        <g ref="amp"/> cepit esse in temporae
+       <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        cepit esse in temporae
         <lb n="70" />
         ex matre uirgine. sed eius incarnatio erat predestinata
 
     <pb n="15r" facs="015r.jpg"/>
         <lb n="110" />
-        cas dies peragit sine
+        cas dies 
+        <choice>
+          <abbr>p&#x0331;agit</abbr>
+          <expan>peragit</expan>
+        </choice>
+        sine
         <choice>
           <orig>cōmunione;</orig>
           <reg>communione;</reg>
@@ -1147,10 +1216,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         <lb n="112" />
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
-        fidem: nascatur <orig>&amp;</orig>
+        fidem: nascatur 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         in nobis uera fide: qui ideo hodie
         <choice>
           <orig>na<g ref="#t_macron"/></orig>
@@ -1159,7 +1232,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="113" />
         est ex matre humanitus ut nos ad se
         <choice>
-          <orig><g ref="#p_macron"/>ducer<g ref="amp"/></orig>
+          <orig>p&#x0331;ducer&amp;</orig>
           <reg>perduceret</reg>
         </choice>
         diuinitus;
@@ -1178,8 +1251,8 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         illo <g ref="amp"/>
         <choice>
-          <orig>omnib</orig>
-          <reg>omnibus</reg>
+          <orig>&amp;omnib:</orig>
+          <reg>et omnibus:</reg>
         </choice>
         <choice>
           <orig>s<g ref="#c_macron"/>is</orig>
@@ -1196,7 +1269,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>manebib:</orig>
           <reg>manebibus:</reg>
         </choice>
-        si in hac mortali uita recta fide <g ref="amp"/> bona
+        si in hac mortali uita recta fide 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        bona
         <lb n="117" />
         operatione
         <choice>
@@ -1207,17 +1285,21 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="118" />
         nolite decipere uos
         <choice>
-          <orig>m<g ref="amp"/></orig>
+          <orig>m&amp;</orig>
           <reg>met</reg>
         </choice>
         ipsos inuicem
         <choice>
-          <orig>fraudib</orig>
+          <orig>fraudib:</orig>
           <reg>fraudibus</reg>
         </choice>
         aut furtis:
         <lb n="119" />
-        quia tu hodie illum decipis [<g ref="amp"/>
+        quia tu hodie illum decipis 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         <choice>
           <orig>animā</orig>
           <reg>animam</reg>
@@ -1227,14 +1309,22 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>tuam</reg>
         </choice>
         <choice>
-          <orig><g ref="#p_macron"/>dis.</orig>
+          <orig>p&#x0331;dis.</orig>
           <reg>perdis</reg>
         </choice>
-         <g ref="amp"/> ille te
-        <lb n="120" />
-        cras decipit. <g ref="amp"/>
         <choice>
-          <orig><g ref="#p_macron"/>dit</orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        ille te
+        <lb n="120" />
+        cras decipit. 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        <choice>
+          <orig>p&#x0331;dit</orig>
           <reg>perdit</reg>
         </choice>
         <choice>
@@ -1243,7 +1333,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         suam; Tunc eritis ambo
         <choice>
-          <orig><g ref="#p_macron"/>diti</orig>
+          <orig>p&#x0331;diti</orig>
           <reg>perditi</reg>
         </choice>
         <lb n="121" />

--- a/edition.xml
+++ b/edition.xml
@@ -1049,7 +1049,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <choice>
           <abbr>feciss&amp;</abbr>
           <expan>fecisset</expan>
-        <choice>:
+        </choice>:
         tunc interrogemus quomodo se
         <choice>
           <orig>ipsū</orig>

--- a/edition.xml
+++ b/edition.xml
@@ -483,7 +483,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
          </choice>
         qui est caritas
         <choice>
-          <orig>ambo</orig>
+          <orig>ambo&#xA75B;</orig>
           <reg>amborum</reg>
         </choice>
         <choice>
@@ -603,7 +603,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="26" />
         aliquis modo
         <choice>
-          <orig>uel<g ref="#l_macron"/></orig>
+          <orig>uell&amp;</orig>
           <reg>uellet</reg>
           </choice>
           erigere altam scalam sibi:
@@ -614,12 +614,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           ascendere
         <lb n="27" />
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         gradus eius
         <choice>
-          <orig>usq</orig>
+          <orig>usq:</orig>
           <reg>usque</reg>
         </choice>
          ad
@@ -629,7 +629,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
          </choice>
           illius ualde uechors
           <choice>
-            <orig>es<g ref="#s_macron"/></orig>
+            <orig>ess&amp;</orig>
             <reg>esset</reg>
           </choice>
           si
@@ -641,14 +641,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
          altius adhuc ascendere
          <choice>
-           <orig>uel<g ref="#l_macron"/>:</orig>
+           <orig>uell&amp;:</orig>
            <reg>uellet</reg>
          </choice>
         quia tanto
         <lb n="29" />
         grauior casus ei eueniret. quanto altius
         <choice>
-          <orig>ascende<g ref="#r_macron"/></orig>
+          <orig>ascender&amp;</orig>
           <reg>ascenderet.</reg>
         </choice>
           sed ad
@@ -666,14 +666,18 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
           Dicit
         <choice>
-            <orig>deniq</orig>
+            <orig>deniq:</orig>
             <reg>denique</reg>
         </choice>
-           dominus ad moysen:
+        <choice>
+          <abbr>d<g ref="#n_macron"/>s</abbr>
+          <expan>dominus</expan>
+        </choice>
+        ad moysen:
         <lb n="32" />
         Non ascendas
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
          gradus ad altare
@@ -683,7 +687,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
          </choice>
            Altare
            <choice>
-             <orig>namq</orig>
+             <orig>namq:</orig>
              <reg>namque</reg>
            </choice>
           in hoc
@@ -742,7 +746,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         ascendere
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         gradus ut
@@ -804,7 +808,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="41" />
         sed
         <choice>
-          <orig>sem<g ref="#p_macron"/></orig>
+          <orig>semp&#x0331;</orig>
           <reg>semper</reg>
         </choice>
          erat:
@@ -814,7 +818,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
          </choice>
         incepit filius: sed
         <choice>
-          <orig>sem<g ref="#p_macron"/></orig>
+          <orig>semp&#x0331;</orig>
           <reg>semper</reg>
         </choice>
         erat sapientia
@@ -836,27 +840,38 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         sed semper
         <lb n="43" />
         erat caritas patris
-        <g ref="amp"/> filii coeternus
-        <g ref="amp"/> consubstantialis ipsis
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        filii coeternus
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        consubstantialis ipsis
         <lb n="44" />
         in una deitate; In creaturis sunt quaedam temporalia: quae-
         <lb n="45" />
-        dam aeterna; Temporalia uero sunt ut pecora pisces uola 45
+        dam aeterna; Temporalia uero sunt ut pecora pisces uola
         <lb n="46" />
-        tilia
+        tilia quae anima carent quae habent
         <choice>
-          <orig>quē</orig>
-          <reg>quae</reg>
-        </choice>
-        anima carent quae habent
-        <choice>
-          <orig>utrumq</orig>
+          <orig>utrumq:</orig>
           <reg>utrumque</reg>
         </choice>
-        initium <g ref="amp"/>
+        initium 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         <lb n="47" />
         finem: quae inceperunt quando creata sunt.
-        <g ref="amp"/> iterum
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        iterum
         <lb n="48" />
         morte
         <choice>
@@ -879,7 +894,11 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         habent quia creata sunt: sed carent fine quia numquam
         <lb n="51" />
         desinunt esse: sicut angeli
-        <g ref="amp"/> anime hominum; Nam
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        anime hominum; Nam
         <lb n="52" />
         creator
         <choice>
@@ -897,13 +916,27 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>initiū</orig>
           <reg>initium</reg>
         </choice>
-        <g ref="amp"/> finis. carens tamen initio
-        <g ref="amp"/> fine;
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        finis. carens tamen initio
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        fine;
         <lb n="54" />
         Nullum
-        tim<g ref="amp"/>
+        <choice>
+          <abbr>tim&amp;</abbr>
+          <expan>timet</expan>
+        </choice>
         quia non
-        hab<g ref="amp"/>
+        <choice>
+          <abbr>hab&amp;</abbr>
+          <expan>habet</expan>
+        </choice>
         <choice>
           <orig>potentiorē</orig>
           <reg>potentiorem</reg>
@@ -915,15 +948,22 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>similem;</reg>
         </choice>
         <choice>
-          <orig>Sem<g ref="#p_macron"/></orig>
+          <orig>Semp&#x0331;</orig>
           <reg>Semper</reg>
         </choice>
         dat:
-        <g ref="amp"/> umquam sua minuit: nec aliquo in
-        <lb n="56" />
-        dig<g ref="amp"/>;
         <choice>
-          <orig>Sem<g ref="#p_macron"/></orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        numquam sua minuit: nec aliquo in
+        <lb n="56" />
+        <choice>
+          <abbr>dig&amp;</abbr>
+          <expan>diget</expan>
+        </choice>;
+        <choice>
+          <orig>Semp&#x0331;</orig>
           <reg>Semper</reg>
         </choice>
         est
@@ -932,7 +972,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>omnipotens</reg>
         </choice>
         <choice>
-          <orig>sem<g ref="#p_macron"/></orig>
+          <orig>semp&#x0331;</orig>
           <reg>semper</reg>
         </choice>
           uult bene.

--- a/edition.xml
+++ b/edition.xml
@@ -1409,7 +1409,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         fiat inferior corpore; Ergo ille homo qui
         <choice>
-          <abbr>semp&#x0331;<macron/></abbr>
+          <abbr>semp&#x0331;</abbr>
           <expan>semper</expan>
         </choice>
 
@@ -2238,33 +2238,42 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
 
 <!--Insert lines 151-239 here-->
 
-<lb n="151" />
+        <lb n="151" />
         sit condita nec
         <choice>
-          <abbr>parte<macron/></abbr>
+          <abbr>part<g ref="#e_macron"/></abbr>
           <expan>partem</expan>
         </choice>
         <choice>
-          <abbr>ea<macron/></abbr>
+          <abbr>e<g ref="#a_macron"/></abbr>
           <expan>eam</expan>
-        </choice>
+        </choice>.
         <choice>
-          <abbr>e<macron/>s</abbr>
+          <abbr>e<g ref="#e_macron"/></abbr>
           <expan>esse</expan>
-        </choice>
+        </choice>.
         dei naturae; Quia si ex dei
 
         <lb n="152" />
-        ess<g ref="amp"/> natura assumpta. peccare non poss<g ref="amp"/>; Unde ait salomon:
+        <choice>
+          <abbr>ess&amp;</abbr>
+          <expan>esset</expan>
+        </choice> 
+        natura assumpta. peccare non 
+        <choice>
+          <abbr>poss&amp;</abbr>
+          <expan>posset</expan>
+        </choice>; 
+        Unde ait salomon:
 
         <lb n="153" />
         reuertatur puluis in
         <choice>
-          <abbr>terra<macron/></abbr>
+          <abbr>terr<g ref="#a_macron"/></abbr>
           <expan>terram</expan>
         </choice>
         <choice>
-          <abbr>sua<macron/></abbr>
+          <abbr>su<g ref="#a_macron"/></abbr>
           <expan>suam</expan>
         </choice>
         unde erat:
@@ -2273,12 +2282,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>sp<macron/>s</abbr>
+          <abbr>s<g ref="#p_macron"/>s</abbr>
           <expan>spiritus</expan>
         </choice>
         redeat ad
         <choice>
-          <abbr>dm<macron/></abbr>
+          <abbr>d<g ref="#m_macron"/></abbr>
           <expan>deum</expan>
         </choice>
 
@@ -2287,12 +2296,16 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="154" />
         qui dedit illum; Et
         <choice>
-          <abbr>dn<macron/>s</abbr>
+          <abbr>d<g ref="#n_macron"/>s</abbr>
           <expan>dominus</expan>
         </choice>
-        loquitur per
+        loquitur
         <choice>
-          <abbr>p<macron/>phetam</abbr>
+          <abbr>p&#x0331;</abbr>
+          <expan>per</abbr>
+        </choice>
+        <choice>
+          <abbr>p&#x0331;phetam</abbr>
           <expan>prophetam</expan>
         </choice>
         ; Omnem flatum
@@ -2304,16 +2317,16 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>Et</expan>
         </choice>
         <choice>
-          <abbr>iteru<macron/></abbr>
+          <abbr>iter<g ref="#u_macron"/></abbr>
           <expan>iterum</expan>
         </choice>
         <choice>
-          <abbr>scriptu<macron/></abbr>
+          <abbr>script<g ref="#u_macron"/></abbr>
           <expan>scriptum</expan>
         </choice>
         est. qui fingit
         <choice>
-          <abbr>sp<macron/>m</abbr>
+          <abbr>s<g ref="#p_macron"/>m</abbr>
           <expan>spiritum</expan>
         </choice>
         hominis in ipso; Et
@@ -2328,9 +2341,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <abbr>&amp;</abbr>
           <expan>et</expan>
         </choice>
-        ipse d<g ref="amp"/> omnibus
+        ipse
         <choice>
-          <abbr>uita<macron/></abbr>
+          <abbr>d&amp;</abbr>
+          <expan>det</expan>
+        </choice> 
+        omnibus
+        <choice>
+          <abbr>uit<g ref="#a_macron"/></abbr>
           <expan>uitam</expan>
         </choice>
         <choice>
@@ -2338,7 +2356,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>sp<macron/>m</abbr>
+          <abbr>s<g ref="#p_macron"/>m</abbr>
           <expan>spiritum</expan>
         </choice>
         ; Triplex est enim
@@ -2352,12 +2370,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="159" />
         enim habent
         <choice>
-          <abbr>haru<macron/></abbr>
+          <abbr>har<g ref="#u_macron"/></abbr>
           <expan>harum</expan>
         </choice>
         partes
         <choice>
-          <abbr>nobiscu<macron/></abbr>
+          <abbr>nobisc<g ref="#u_macron"/></abbr>
           <expan>nobiscum</expan>
         </choice>
         bestiae
@@ -2370,7 +2388,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="160" />
         munes id est
         <choice>
-          <abbr>concupiscentia<macron/></abbr>
+          <abbr>concupiscenti<g ref="#a_macron"/></abbr>
           <expan>concupiscentiam</expan>
         </choice>
         <choice>
@@ -2380,7 +2398,17 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         iram; Homo solus inter in
 
         <lb n="161" />
-        rationabiles ratione uig<g ref="amp"/>. consilio ual<g ref="amp"/> intellegentia ante
+        rationabiles ratione 
+        <choice>
+          <abbr>vig&amp;</abbr>
+          <expan>viget</expan>
+        </choice>.
+        consilio 
+        <choice>
+          <abbr>val&amp;</abbr>
+          <expan>valet</expan>
+        </choice>
+        intellegentia ante
 
         <lb n="162" />
         cellit; Concupiscentia data est homini ad cupiscenda quae
@@ -2393,23 +2421,23 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         quae sibi ad
         <choice>
-          <abbr>salute<macron/></abbr>
+          <abbr>salut<g ref="#e_macron"/></abbr>
           <expan>salutem</expan>
         </choice>
         <choice>
-          <abbr>p<macron/>ficiant</abbr>
+          <abbr>p&#x0331;ficiant</abbr>
           <expan>proficiant</expan>
         </choice>
         <choice>
-          <abbr>sempiterna<macron/></abbr>
+          <abbr>sempitern<g ref="#a_macron"/></abbr>
           <expan>sempiternam</expan>
-        </choice>
-        ; Si uero
+        </choice>; 
+        Si uero
 
         <lb n="164" />
         corrumpitur.
         <choice>
-          <abbr>nascitu<macron/></abbr>
+          <abbr>nasci<g ref="#t_macron"/></abbr>
           <expan>nascitur</expan>
         </choice>
         ex ea gastrimargia fornicatio.
@@ -2424,7 +2452,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="166" />
         peccatis homo seruiat dominis quia iuxta
         <choice>
-          <abbr>dn<macron/>i</abbr>
+          <abbr>d<g ref="#n_macron"/>i</abbr>
           <expan>domini</expan>
         </choice>
         uocem qui
@@ -2432,12 +2460,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="167" />
         facit
         <choice>
-          <abbr>peccatu<macron/></abbr>
+          <abbr>peccat<g ref="#u_macron"/></abbr>
           <expan>peccatum</expan>
         </choice>
         seruus est peccati; Ex qua corrupta
         <choice>
-          <abbr>p<macron/>cedit</abbr>
+          <abbr>p&#x0331;cedit</abbr>
           <expan>procedit</expan>
         </choice>
 
@@ -2452,7 +2480,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="169" />
         hominis
         <choice>
-          <abbr>uita<macron/></abbr>
+          <abbr>uit<g ref="#a_macron"/></abbr>
           <expan>uitam</expan>
         </choice>
         regere
@@ -2464,22 +2492,20 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
 
         <lb n="170" />
         <choice>
-          <abbr>orit<macron/></abbr>
+          <abbr>ori<g ref="#t_macron"/></abbr>
           <expan>oritur</expan>
-        </choice>
-        .
+        </choice>.
         <choice>
-          <abbr>sup<macron/>bia</abbr>
+          <abbr>sup&#x0331;bia</abbr>
           <expan>superbia</expan>
-        </choice>
-        .
+        </choice>.
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
         </choice>
         caeno doxia; Paruulis
         <choice>
-          <abbr>eni<macron/></abbr>
+          <abbr>en<g ref="#i_macron"/></abbr>
           <expan>enim</expan>
         </choice>
         ratio crescit non
@@ -2491,7 +2517,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>p<macron/>ficiendo</abbr>
+          <abbr>p&#x0331;ficiendo</abbr>
           <expan>proficiendo</expan>
         </choice>
         ad uirtutem non maior fit. sed melior
@@ -2499,28 +2525,32 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="172" />
         nec
         <choice>
-          <abbr>corporale<macron/></abbr>
+          <abbr>corporal<g ref="#e_macron"/></abbr>
           <expan>corporalem</expan>
         </choice>
         recipit
         <choice>
-          <abbr>quantitate<macron/></abbr>
+          <abbr>quantitat<g ref="#e_macron"/></abbr>
           <expan>quantitatem</expan>
-        </choice>
-        ; Hab<g ref="amp"/> igitur anima in
+        </choice>; 
+        <choice>
+          <abbr>Hab&amp;</abbr>
+          <expan>Habet</expan>
+        </choice> 
+        igitur anima in
 
         <lb n="173" />
         sua natura ut
         <choice>
-          <abbr>dixim<macron/></abbr>
+          <abbr>dixi<g ref="#m_macron"/></abbr>
           <expan>diximus</expan>
         </choice>
         <choice>
-          <abbr>imagine<macron/></abbr>
+          <abbr>imagin<g ref="#e_macron"/></abbr>
           <expan>imaginem</expan>
         </choice>
         <choice>
-          <abbr>sc<macron/>ae</abbr>
+          <abbr>sc<g ref="#a_macron"/>e</abbr>
           <expan>sanctae</expan>
         </choice>
         trinitatis. in eo quod in
@@ -2528,22 +2558,26 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="174" />
         tellegentiam
         <choice>
-          <abbr>uoluntate<macron/></abbr>
+          <abbr>uoluntat<g ref="#e_macron"/></abbr>
           <expan>uoluntatem</expan>
-        </choice>
-        :
+        </choice>:
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>memoria<macron/></abbr>
+          <abbr>memori<g ref="#a_macron"/></abbr>
           <expan>memoriam</expan>
-        </choice>memoria[m] hab<g ref="amp"/>; Una est
+        </choice> 
+        <choice>
+          <abbr>hab&amp;</abbr>
+          <expan>habet</expan>
+        </choice>; 
+        Una est
 
         <lb n="175" />
         <choice>
-          <abbr>eni<macron/></abbr>
+          <abbr>en<g ref="#i_macron"/></abbr>
           <expan>enim</expan>
         </choice>
         anima quae mens dicitur. una uita.
@@ -2554,51 +2588,51 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         una substantia.
 
         <lb n="176" />
-        quae haec tria hab<g ref="amp"/> in se: sed
+        quae haec tria 
         <choice>
-          <abbr>h<macron/>ec</abbr>
-          <expan>haec</expan>
-        </choice>
-        tria non sunt tres uitae
+          <abbr>hab&amp;</abbr>
+          <expan>habet</expan>
+        </choice> 
+        in se: sed haec tria non sunt tres uitae
 
         <lb n="177" />
-        sed una uita; Nec tres
-        <choice>
-          <abbr>substanti<macron/>e</abbr>
-          <expan>substantiae</expan>
-        </choice> sed una; Quod uero ani
+        sed una uita; Nec tres substantiae sed una; Quod uero ani
 
         <lb n="178" />
         ma uel mens uel uita. uel substantia dicitur. ad se ipsam
 
         <lb n="179" />
         <choice>
-          <abbr>dicit<macron/></abbr>
+          <abbr>dici<g ref="#t_macron"/></abbr>
           <expan>dicitur</expan>
-        </choice>
-        ; Quod uero memoria. uel intellegentia. uel uolun
+        </choice>; 
+        Quod uero memoria. uel intellegentia. uel uolun
 
         <lb n="180" />
         tas dicitur. ad aliquid relatiue dicitur; Nam in his
         <choice>
-          <abbr>trib<macron/></abbr>
+          <abbr>trib:</abbr>
           <expan>tribus</expan>
         </choice>
 
         <lb n="181" />
         unitas
         <choice>
-          <abbr>quaeda<macron/></abbr>
+          <abbr>quaed<g ref="#a_macron"/></abbr>
           <expan>quadam</expan>
         </choice>
         est. quia quicquid ad se ipsa singula
         <choice>
-          <abbr>dicunt<macron/></abbr>
+          <abbr>dicun<g ref="#t_macron"/></abbr>
           <expan>dicuntur</expan>
         </choice>
 
         <lb n="182" />
-        <g ref="amp"/>iam simul: non pluraliter sed singulariter dicuntur;
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        iam simul: non pluraliter sed singulariter dicuntur;
 
         <pb n="16v" facs="data/images/fol_5v.png" />
 
@@ -2636,34 +2670,34 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         sic in singulis singula capiuntur;
         <choice>
-          <abbr>Considerem<macron/></abbr>
+          <abbr>Considere<g ref="#m_macron"/></abbr>
           <expan>Consideremus</expan>
         </choice>
         <choice>
-          <abbr>aute<macron/></abbr>
+          <abbr>aut<g ref="#e_macron"/></abbr>
           <expan>autem</expan>
         </choice>
 
         <lb n="186" />
         miram uelocitatem animae in formandis rebus. quae
         <choice>
-          <abbr>p<macron/>cipit</abbr>
+          <abbr>p&#x0331;cipit</abbr>
           <expan>percipit</expan>
         </choice>
 
         <lb n="187" />
         <choice>
-          <abbr>p<macron/></abbr>
+          <abbr>p&#x0331;</abbr>
           <expan>per</expan>
         </choice>
         carnales sensus a
         <choice>
-          <abbr>quib<macron/></abbr>
+          <abbr>quib:</abbr>
           <expan>quibus</expan>
         </choice>
         quasi
         <choice>
-          <abbr>p<macron/></abbr>
+          <abbr>p&#x0331;</abbr>
           <expan>per</expan>
         </choice>
         quosdam nuntios quicquid
@@ -2671,28 +2705,28 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="188" />
         rerum
         <choice>
-          <abbr>uisibiliu<macron/></abbr>
+          <abbr>uisibili<g ref="#u_macron"/></abbr>
           <expan>uisibilium</expan>
         </choice>
         <choice>
-          <abbr>cognitaru<macron/></abbr>
+          <abbr>cognitar<g ref="#u_macron"/></abbr>
           <expan>cognitarum</expan>
         </choice>
         uel
         <choice>
-          <abbr>incognitaru<macron/></abbr>
+          <abbr>incognitar<g ref="#u_macron"/></abbr>
           <expan>incognitarum</expan>
         </choice>
         <choice>
-          <abbr>p<macron/>cipit</abbr>
+          <abbr>p&#x0331;cipit</abbr>
           <expan>percipit</expan>
-        </choice>
-        : mox
+        </choice>: 
+        mox
 
         <lb n="189" />
         in se ipsa
         <choice>
-          <abbr>earu<macron/></abbr>
+          <abbr>ear<g ref="#u_macron"/></abbr>
           <expan>earum</expan>
         </choice>
         ineffabili celeritate format figuras. for
@@ -2703,16 +2737,16 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="191" />
         enim qui romam
         <choice>
-          <abbr>quonda<macron/></abbr>
+          <abbr>quond<g ref="#a_macron"/></abbr>
           <expan>quondam</expan>
         </choice>
         uidit.
         <choice>
-          <abbr>iteru<macron/></abbr>
+          <abbr>iter<g ref="#u_macron"/></abbr>
           <expan>iterum</expan>
         </choice>
         <choice>
-          <abbr>cu<macron/></abbr>
+          <abbr>c<g ref="#u_macron"/></abbr>
           <expan>cum</expan>
         </choice>
         nomen audierit
@@ -2726,27 +2760,20 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         format qualis sit; Et ad
 
         <lb n="193" />
-        huc mirabilius est quod incognitae res si lectae uel audit[a]e
+        huc mirabilius est quod incognitae res si lectae uel auditae
 
         <lb n="194" />
         erunt in
         <choice>
-          <abbr>auri:</abbr>
+          <abbr>aurib:</abbr>
           <expan>aurbus</expan>
         </choice>
+        animae: statim format
         <choice>
-          <abbr>anim<macron/></abbr>
-          <expan>animae</expan>
-        </choice>
-        : statim format
-        <choice>
-          <abbr>figura<macron/></abbr>
+          <abbr>figur<g ref="#a_macron"/></abbr>
           <expan>figuram</expan>
         </choice>
-        <choice>
-          <abbr>ignote</abbr>
-          <expan>ignotae</expan>
-        </choice>
+        ignotae
 
         <lb n="195" />
         rei; Ex notis enim speciebus fingit ignota: Ex qua ueloci
@@ -2757,7 +2784,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="197" />
         aut sensa: aut odorata: aut gustata.
         <choice>
-          <abbr>iteru<macron/></abbr>
+          <abbr>iter<g ref="#u_macron"/></abbr>
           <expan>iterum</expan>
         </choice>
         inuenta recog
@@ -2773,15 +2800,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="199" />
         tis est ut nec
         <choice>
-          <abbr>cu</abbr>
+          <abbr>c<g ref="#u_macron"/></abbr>
           <expan>cum</expan>
         </choice>
-        sopita est conquiescat;
-        <choice>
-          <abbr>Tante<macron/></abbr>
-          <expan>Tantae</expan>
-        </choice>
-        celeritatis
+        sopita est conquiescat; Tantae celeritatis
 
         <lb n="200" />
         ut uno temporis puncto
@@ -2789,45 +2811,58 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <abbr>caelu</abbr>
           <expan>caelum</expan>
         </choice>
-        conlustr<g ref="amp"/> si uelit; Maria
+        <choice>
+          <abbr>conlustr&amp;</abbr>
+          <expan>conlustret</expan>
+        </choice>
+        si uelit; Maria
 
         <lb n="201" />
         <choice>
-          <abbr>p<macron/>uolat</abbr>
+          <abbr>p&#x0331;uolat</abbr>
           <expan>peruolat</expan>
-        </choice>
-        . terras
+        </choice>. 
+        terras
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
         </choice>
         urbes
         <choice>
-          <abbr>p<macron/>agr&amp;</abbr>
+          <abbr>p&#x0331;agr&amp;</abbr>
           <expan>peragret</expan>
-        </choice>
-        . omnia in conspectu sibi
+        </choice>. 
+        omnia in conspectu sibi
 
         <lb n="202" />
         cogitando constituens; Sed
         <choice>
-          <abbr>cu<macron/></abbr>
+          <abbr>c<g ref="#u_macron"/></abbr>
           <expan>cum</expan>
         </choice>
         de roma cogitat. non eo
 
         <lb n="203" />
-        momento de hierusalem potest cogitare; Uel
+        momento de 
         <choice>
-          <abbr>cu<macron/></abbr>
+          <abbr>hir<g ref="#l_macron"/>m</abbr>
+          <expan>hierusalem</expan>
+        </choice>
+        potest cogitare; Uel
+        <choice>
+          <abbr>c<g ref="#u_macron"/></abbr>
           <expan>cum</expan>
         </choice>
         de qua
 
         <lb n="204" />
-        lib<g ref="amp"/> una
         <choice>
-          <abbr>remeditat<macron/></abbr>
+          <abbr>lib&amp;</abbr>
+          <expan>libet</expan>
+        </choice>
+        una
+        <choice>
+          <abbr>remedita<g ref="#t_macron"/></abbr>
           <expan>remeditatur</expan>
         </choice>
         non potest eo momento de
@@ -2839,39 +2874,30 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="205" />
         meditari. sed hoc
         <choice>
-          <abbr>unu<macron/></abbr>
+          <abbr>un<g ref="#u_macron"/></abbr>
           <expan>unum</expan>
         </choice>
         illi tunc presens est donec uel
 
         <lb n="206" />
-        citius uel tardius
-        <choice>
-          <abbr>he<macron/>c</abbr>
-          <expan>haec</expan>
-        </choice>
-        cogitatio recedat
+        citius uel tardius haec cogitatio recedat
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
         </choice>
         alia
         <choice>
-          <abbr>sup<macron/></abbr>
+          <abbr>sup&#x0331;</abbr>
           <expan>super</expan>
         </choice>
 
         <lb n="207" />
         ueniat; At
         <choice>
-          <abbr>di<macron/></abbr>
+          <abbr>d<g ref="#i_macron"/></abbr>
           <expan>dei</expan>
         </choice>
-        omnipotentis
-        <choice>
-          <abbr>nature<macron/></abbr>
-          <expan>naturae</expan>
-        </choice>
+        omnipotentis naturae
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
@@ -2885,14 +2911,13 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>semp<macron/></abbr>
+          <abbr>semp&#x0331;</abbr>
           <expan>semper</expan>
         </choice>
         <choice>
-          <abbr>p<macron/>sentia</abbr>
+          <abbr><g ref="#p_macron"/>sentia</abbr>
           <expan>praesentia</expan>
-        </choice>
-        .
+        </choice>.
 
         <lb n="209" />
         <choice>
@@ -2900,7 +2925,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>numqua</abbr>
+          <abbr>numqu<g ref="#a_macron"/></abbr>
           <expan>numquam</expan>
         </choice>
         recedentia.
@@ -2912,7 +2937,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
 
         <lb n="210" />
         <choice>
-          <abbr>d<macron/>s</abbr>
+          <abbr><g ref="#d_macron"/>s</abbr>
           <expan>deus</expan>
         </choice>
         <choice>
@@ -2927,7 +2952,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <pb n="17r" facs="data/images/fol_5v.png" />
 
         <lb n="212" />
-        presentia hab<g ref="amp"/>; Anima
+        presentia 
+        <choice>
+          <abbr>hab&amp;</abbr>
+          <expan>habet</expan>
+        </choice>; 
+        Anima
         <choice>
           <abbr>namq:</abbr>
           <expan>namque</expan>
@@ -2937,7 +2967,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="213" />
         uero uita
         <choice>
-          <abbr>d<macron/>s</abbr>
+          <abbr>d<g ref="#s_macron"/></abbr>
           <expan>deus</expan>
         </choice>
         est; Dum anima corpus deserit: moritur;
@@ -2945,7 +2975,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="214" />
         Animae uero mors est dum eam
         <choice>
-          <abbr>d<macron/>s</abbr>
+          <abbr>d<g ref="#s_macron"/></abbr>
           <expan>deus</expan>
         </choice>
         deserit dono suae
@@ -2958,7 +2988,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         ob
         <choice>
-          <abbr>magnitude<macron/></abbr>
+          <abbr>magnitud<g ref="#e_macron"/></abbr>
           <expan>magnitudem</expan>
         </choice>
         scelerum moritur meliore
@@ -2996,29 +3026,30 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="221" />
         maligno
         <choice>
-          <abbr>sp<macron/>u</abbr>
+          <abbr>s<g ref="#p_macron"/>u</abbr>
           <expan>spiritu</expan>
         </choice>
         instigante deprauata est, beatitudinem
         <choice>
-          <abbr>p<macron/>di</abbr>
+          <abbr>p&#x0331;di</abbr>
           <expan>perdi</expan>
-        </choice> p[er]di
+        </choice>
 
         <lb n="222" />
         dit.
         <choice>
-          <abbr>aeternitate<macron/></abbr>
+          <abbr>aeternitat<g ref="#e_macron"/></abbr>
           <expan>aeternitatem</expan>
         </choice>
         <choice>
-          <abbr>p<macron/>dere</abbr>
+          <abbr>p&#x0331;dere</abbr>
           <expan>perdere</expan>
-        </choice> non potuit; Cuius pulchritudo
+        </choice> 
+        non potuit; Cuius pulchritudo
 
         <lb n="223" />
         <choice>
-          <abbr>uirtu<macron/></abbr>
+          <abbr>uirt<g ref="#u_macron"/></abbr>
           <expan>uirtus</expan>
         </choice>
         est.
@@ -3027,20 +3058,20 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>ei<macron/></abbr>
+          <abbr>e<g ref="#i_macron"/></abbr>
           <expan>eius</expan>
         </choice>
         deformitas
         <choice>
-          <abbr>uitiu<macron/></abbr>
+          <abbr>uiti<g ref="#u_macron"/></abbr>
           <expan>uitium</expan>
-        </choice>
-        ; Cuius excellentiores
+        </choice>; 
+        Cuius excellentiores
 
         <lb n="224" />
         uirtutes quattuor esse
         <choice>
-          <abbr>manifestu<macron/></abbr>
+          <abbr>manifest<g ref="#u_macron"/></abbr>
           <expan>manifestum</expan>
         </choice>
         est; Id est, prudentia
@@ -3048,12 +3079,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="225" />
         quae
         <choice>
-          <abbr>d<macron/>m</abbr>
+          <abbr>d<g ref="#m_macron"/></abbr>
           <expan>deum</expan>
         </choice>
         intellegit
         <choice>
-          <abbr>amandu<macron/></abbr>
+          <abbr>amand<g ref="#u_macron"/></abbr>
           <expan>amandum</expan>
         </choice>.
         <choice>
@@ -3065,7 +3096,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="226" />
         discernit; Iustitia, qua
         <choice>
-          <abbr>d<macron/>s</abbr>
+          <abbr>d<g ref="#s_macron"/></abbr>
           <expan>deus</expan>
         </choice>
         colitur
@@ -3074,25 +3105,23 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>et</expan>
         </choice>
         <choice>
-          <abbr>amat<macron/></abbr>
+          <abbr>ama<g ref="#t_macron"/></abbr>
           <expan>amatur</expan>
         </choice>
-        ,
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>
         </choice>
         recte
         <choice>
-          <abbr>uiuit<macron/></abbr>
+          <abbr>uiui<g ref="#t_macron"/></abbr>
           <expan>uiuitur</expan>
-        </choice>
-        ;
+        </choice>;
 
         <lb n="227" />
         Temperantia. qua
         <choice>
-          <abbr>concupiscentia<macron/></abbr>
+          <abbr>concupiscenti<g ref="#a_macron"/></abbr>
           <expan>concupiscentiam</expan>
         </choice>
         uel iram gubernat;
@@ -3100,7 +3129,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="228" />
         Fortitudo, qua
         <choice>
-          <abbr>p<macron/></abbr>
+          <abbr>p&#x0331;</abbr>
           <expan>pro</expan>
         </choice>
         dei amore fortiter omnia aduersa
@@ -3113,12 +3142,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
 
         <lb n="231" />
         <choice>
-          <abbr>eni<macron/></abbr>
+          <abbr>en<g ref="#i_macron"/></abbr>
           <expan>enim</expan>
         </choice>
         animae summa beatitudo.
         <choice>
-          <abbr>eu<macron/></abbr>
+          <abbr>e<g ref="#u_macron"/></abbr>
           <expan>eum</expan>
         </choice>
         diligere a quo est.
@@ -3135,35 +3164,27 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         illis
         <choice>
-          <abbr>p<macron/>desse</abbr>
+          <abbr>p&#x0331;desse</abbr>
           <expan>prodesse</expan>
         </choice>
 
         <lb n="233" />
         in
         <choice>
-          <abbr>quant</abbr>
+          <abbr>quant<g ref="#u_macron"/></abbr>
           <expan>quantum</expan>
         </choice>
         ualeat; Hoc modo anima definiri potest.
 
         <lb n="234" />
-        iuxta
+        iuxta suae
         <choice>
-          <abbr>su<macron/>e</abbr>
-          <expan>suae</expan>
-        </choice>
-        <choice>
-          <abbr>p<macron/>prietatem</abbr>
+          <abbr>p&#x0331;prietatem</abbr>
           <expan>proprietatem</expan>
         </choice>
+        naturae; Anima est
         <choice>
-          <abbr>natur<macron/>e</abbr>
-          <name></name>expan>naturae</expan>
-        </choice>
-        ; Anima est
-        <choice>
-          <abbr>sp<macron/>s</abbr>
+          <abbr>s<g ref="#p_macron"/>s</abbr>
           <expan>spiritus</expan>
         </choice>
         intel
@@ -3171,24 +3192,24 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="235" />
         lectualis. rationalis:
         <choice>
-          <abbr>semp<macron/></abbr>
+          <abbr>semp&#x0331;</abbr>
           <expan>semper</expan>
         </choice>
         inmota
         <choice>
-          <abbr>semp<macron/></abbr>
+          <abbr>semp&#x0331;</abbr>
           <expan>semper</expan>
         </choice>
         uiuens. bonae.
 
         <lb n="236" />
         <choice>
-          <abbr>maleq:<macron/></abbr>
+          <abbr>maleq:</abbr>
           <expan>maleque</expan>
         </choice>
         uoluntatis capax. sed
         <choice>
-          <abbr>dm<macron/></abbr>
+          <abbr>d<g ref="#m_macron"/></abbr>
           <expan>domini</expan>
         </choice>
         benignitate creatoris
@@ -3201,18 +3222,19 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <choice>
           <abbr>quib:</abbr>
           <expan>quibus</expan>
-        </choice> ipse
+        </choice> 
+        ipse
         <choice>
-          <abbr>dn<macron/>s</abbr>
+          <abbr>d<g ref="#n_macron"/>s</abbr>
           <expan>dominus</expan>
         </choice>
         uoluit. ad
         <choice>
-          <abbr>regendu<macron/></abbr>
+          <abbr>regend<g ref="#u_macron"/></abbr>
           <expan>regendum</expan>
         </choice>
         <choice>
-          <abbr>mot<macron/></abbr>
+          <abbr>mo<g ref="#t_macron"/></abbr>
           <expan>motus</expan>
         </choice>
 
@@ -3238,7 +3260,12 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>potestatē</orig>
           <reg>potestate</reg>
         </choice>
-         exeundi de carne <g ref="amp"/> redeundi
+        exeundi de carne 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        redeundi
          <choice>
            <orig>iterū</orig>
            <reg>iterum</reg>
@@ -3257,27 +3284,32 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
           <choice>
             <orig>carniq:</orig>
-            <reg>carnique:</reg>
+            <reg>carnique</reg>
           </choice>
         inmisit; In qua est amor
         <lb n="244" />
-        naturaliter, qui amor intellectu discernendus est <g ref="amp"/> ratio
+        naturaliter qui amor intellectu discernendus est 
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        ratio
         <lb n="245" />
         ne ut inlicitas delectationes
         <choice>
-          <orig>deuit<g ref="amp"/>.</orig>
-          <reg>deuitet</reg>
+          <orig>deuit&amp;.</orig>
+          <reg>deuitet.</reg>
         </choice>
-        <g ref="amp"/> ea
         <choice>
-          <orig>am<g ref="amp"/></orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        ea
+        <choice>
+          <orig>am&amp;</orig>
           <reg>amet</reg>
         </choice>
-        <choice>
-          <orig>quē</orig>
-          <reg>quae</reg>
-        </choice>
-        amanda
+        quae amanda
         <lb n="246" />
         sunt;
         <choice>
@@ -3294,8 +3326,8 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>nuncupatur</reg>
         </choice>
         <choice>
-          <orig>nomini<g ref="#b_macron"/>;</orig>
-          <reg>nominibus</reg>
+          <orig>nominib:;</orig>
+          <reg>nominibus;</reg>
         </choice>
         <lb n="247" />
         Anima est
@@ -3328,7 +3360,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>dū</orig>
           <reg>dum</reg>
         </choice>
-        sapit,
+        sapit
         <choice>
           <orig>ani<g ref="#m_macron"/></orig>
           <reg>animus</reg>
@@ -3344,9 +3376,9 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>dum</reg>
         </choice>
         <lb n="249" />
-        discernit, ratio
+        discernit ratio
         <choice>
-          <orig>ē:</orig>
+          <orig>.ē.:</orig>
           <reg>est:</reg>
         </choice>
         <choice>
@@ -3360,19 +3392,17 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         recor
         <lb n="250" />
-        datur memoria est. Non tamen haec diuidentur in sub-
+        datur memoria est. Non tamen haec diuidentur in sub
         <lb n="251" />
-        stantia quia
-        <choice>
-          <orig>hēc</orig>
-          <reg>haec</reg>
-        </choice>
-        omnia, una est anima; Inter
+        stantia quia haec omnia, una est anima; Inter
         <choice>
           <orig>s<g ref="#p_macron"/>m</orig>
           <reg>spiritum</reg>
         </choice>
-        <g ref="amp"/>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         <choice>
           <orig>animā</orig>
           <reg>animam</reg>
@@ -3380,7 +3410,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="252" />
         huius modi potest differentia
         <choice>
-          <orig>ēe</orig>
+          <orig>.eē.</orig>
           <reg>esse</reg>
         </choice>
         quod omnis anima
@@ -3394,9 +3424,14 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
            <orig>s<g ref="#p_macron"/>s</orig>
            <reg>spiritus</reg>
          </choice>
-        anima: Sed <g ref="amp"/> paulus
+        anima: Sed 
         <choice>
-          <orig>apt<g ref="#s_macron"/></orig>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
+        paulus
+        <choice>
+          <orig>apts</orig>
           <reg>apostolus</reg>
         </choice>
         <lb n="254" />
@@ -3405,7 +3440,10 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <orig>s<g ref="#p_macron"/>m</orig>
           <reg>spiritum</reg>
         </choice>
-        <g ref="amp"/>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         <choice>
           <orig>mentē</orig>
           <reg>mentem</reg>
@@ -3420,21 +3458,25 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
            <orig>psallā</orig>
            <reg>psallam</reg>
          </choice>
-        <g ref="amp"/> mente;
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice> 
+        mente;
         <choice>
           <orig>S<g ref="#p_macron"/>u</orig>
           <reg>Spiritu</reg>
         </choice>
-        psallit, qui rerum obscuras sig-
+        psallit, qui rerum obscuras sig
         <lb n="256" />
-        nificationes non intellegens ore
+        nificationes non intellegens. ore
         <choice>
-          <orig><g ref="#p_macron"/>fert.</orig>
+          <orig>p&#x0331;fert.</orig>
           <reg>profert.</reg>
         </choice>
         psallit mente
         <lb n="257" />
-        qui easdem significationes mentis efficacia intellegit;
+        qui easdem significationes. mentis efficacia intellegit;
         <lb n="258" />
         Regit
         <choice>
@@ -3443,11 +3485,11 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         anima corpus
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         <choice>
-          <orig>quin<g ref="#q_macron"/></orig>
+          <orig>quinq:</orig>
           <reg>quinque</reg>
         </choice>
         sensus quasi de sede
@@ -3465,17 +3507,17 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         quid cuique membro
         <choice>
-          <orig>imper<g ref="amp"/></orig>
+          <orig>imper&amp;</orig>
           <reg>imperet</reg>
         </choice>
         <choice>
            <orig>faciendū;</orig>
-           <reg>faciendum</reg>
+           <reg>faciendum;</reg>
          </choice>
         Quid
         <lb n="261" />
         <choice>
-          <orig>cui<g ref="#q_macron"/></orig>
+          <orig>cuiq:</orig>
           <reg>cuique</reg>
         </choice>
         consentiat in desiderio suae naturae. ne quid in
@@ -3513,18 +3555,24 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="264" />
         naturae dignitate precellit; Quae etiam
         <choice>
-          <orig><g ref="#p_macron"/></orig>
+          <orig>p&#x0331;</orig>
           <reg>per</reg>
         </choice>
         <choice>
           <orig>lucē</orig>
           <reg>lucem</reg>
         </choice>
-        <g ref="amp"/>
+        <choice>
+          <abbr>&amp;</abbr>
+          <expan>et</expan>
+        </choice>
         <choice>
           <orig>aerē</orig>
           <reg>aerem</reg>
         </choice>
+
+<!--Left off here!-->
+
         <lb n="265" />
         <choice>
           <orig>quē</orig>

--- a/edition.xml
+++ b/edition.xml
@@ -2603,7 +2603,6 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <pb n="16v" facs="data/images/fol_5v.png" />
 
         <lb n="183" />
-        <---LINE STARTS A BIT BEFORE NORMAL - EXTRA TEXT ADDED--!>
         Intellego me intellegere uelle:
         <choice>
           <abbr>&amp;</abbr>
@@ -2794,7 +2793,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
 
         <lb n="201" />
         <choice>
-          <abbr>p>macron/>uolat</abbr>
+          <abbr>p<macron/>uolat</abbr>
           <expan>peruolat</expan>
         </choice>
         . terras
@@ -2805,7 +2804,6 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         urbes
         <choice>
           <abbr>p<macron/>agr&amp;</abbr>
-          <---IS THIS CORRECT?-->
           <expan>peragret</expan>
         </choice>
         . omnia in conspectu sibi
@@ -3057,8 +3055,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <choice>
           <abbr>amandu<macron/></abbr>
           <expan>amandum</expan>
-        </choice>
-        .
+        </choice>.
         <choice>
           <abbr>&amp;</abbr>
           <expan>et</expan>

--- a/edition.xml
+++ b/edition.xml
@@ -252,7 +252,7 @@
         <mapping type="normalized">ꝵ</mapping>
         <mapping type="diplomatic">ꝵ</mapping>
     </char>
-    <char xml:id=“p_with_flourish>
+    <char xml:id="p_with_flourish">
         <localProp name="name"
             value="Latin Small Letter P With Flourish"/>
         <mapping type="normalized">ꝓ</mapping>

--- a/edition.xml
+++ b/edition.xml
@@ -296,7 +296,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <expan>iesus</expan>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/>s</foreign></orig>
+          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/>s</foreign></orig>
           <reg>christus</reg>
         </choice>
         hac ipsa die natus sit uera humanita
@@ -434,7 +434,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         interrogauerunt
         <choice>
-          <orig><foreign xml:lang="grc">x<g ref="#r_macron"/></foreign>m</orig>
+          <orig><foreign xml:lang="grc"/>x<g ref="#r_macron"/></foreign>m</orig>
           <reg>Christum</reg>
         </choice>
         dicen
@@ -583,7 +583,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         transscendere uult
         <choice>
-          <orig><foreign xml:lang="grc">x<g ref="#r_macron"/></foreign>m,</orig>
+          <orig><foreign xml:lang="grc"/>x<g ref="#r_macron"/></foreign>m,</orig>
             <reg>christum,</reg>
           </choice>
         <lb n="25" />
@@ -1258,7 +1258,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         unus
         <choice>
-          <orig><foreign xml:lang="grc">xps</orig>
+          <orig><foreign xml:lang="grc"/>xps</orig>
           <reg>christus</reg>
         </choice>
         ; Creaturae uero quas unus
@@ -1621,7 +1621,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="106" />
         mus cum ad sacrificium
         <choice>
-          <orig><foreign xml:lang="grc">xpi</orig>
+          <orig><foreign xml:lang="grc"/>xpi</orig>
           <reg>christi</reg>
         </choice>
         <choice>
@@ -1633,7 +1633,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="107" />
         hodie debent
         <choice>
-          <orig><foreign xml:lang="grc">xpiani</orig>
+          <orig><foreign xml:lang="grc"/>xpiani</orig>
           <reg>christiani</reg>
         </choice>
         accedere ad
@@ -1642,7 +1642,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>sacrificium</reg>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc">xpi</orig>
+          <orig><foreign xml:lang="grc"/>xpi</orig>
           <reg>christi</reg>
         </choice>
         . quia ual
@@ -1679,7 +1679,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         </choice>
         Semel uero natus est
         <choice>
-          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>s</orig>
+          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign>s</orig>
           <reg>christus</reg>
         </choice>
         <lb n="111" />
@@ -1886,7 +1886,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
           <reg>omnibus</reg>
         </choice>
         <choice>
-          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>anis</orig>
+          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign>anis</orig>
           <reg>christianis</reg>
         </choice>
         custodienda
@@ -2021,7 +2021,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="132" />
         qui ueritatem diligit:
         <choice>
-          <orig><orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign></orig>m</orig>
+          <orig><orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign></orig>m</orig>
           <reg>christum</reg>
         </choice>
         sequitur qui dixit. ego sum uia
@@ -2067,7 +2067,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         <lb n="136" />
         fratres quia nichil est tam necesse homini
         <choice>
-          <orig><orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign></orig>ano</orig>
+          <orig><orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign></orig>ano</orig>
           <reg>christiano</reg>
         </choice>
         scire
@@ -3760,7 +3760,7 @@ The 'rend="3lines"' function was not appearing in the EVT window. Might this sam
         nos
         <lb n="285" />
         <choice>
-          <orig><foreign xml:lang="grc">x<g ref="#p_macron"/></foreign>s</orig>
+          <orig><foreign xml:lang="grc"/>x<g ref="#p_macron"/></foreign>s</orig>
           <reg>christus</reg>
         </choice>
         qui est uera sapientia uera que uita: qui uiuit cum


### PR DESCRIPTION
See the same note on the TASP Google Doc:

The “p̱” symbol—where the “p” has a horizontal line through the descender, although it is not quite rendering correctly here in Good Drive—should be best represented in XML code according to TEI standards by this sequence of characters: p&#x0331; 
-The “p” is just a regular p.
-The &#x tells the computer that the following sequence is a hexadecimal value. 
-The 0331; is the Unicode hexadecimal sequence for the “combining macron below” mark, which should overlay a low horizontal line over the descender of the “p.”

I have made these changes (i.e., added the Unicode sequence) to the p’s in the first 7 lines of Boulogne, and will continue making them as the need arises.